### PR TITLE
fix(css): revert calc(var()) range notation — breaks PostCSS

### DIFF
--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -21,6 +21,7 @@
     "declaration-block-single-line-max-declarations": null,
     "declaration-block-no-duplicate-properties": null,
     "property-no-vendor-prefix": null,
-    "no-duplicate-selectors": null
+    "no-duplicate-selectors": null,
+    "media-feature-range-notation": null
   }
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -480,7 +480,7 @@ html, body, #__next {
 .nav-responsive { display: flex; }
 .mobile-dropdown { display: none; }
 
-@media (width <= calc(var(--collapse-threshold) - 1px)) {
+@media (max-width: calc(var(--collapse-threshold) - 1px)) {
   .nav-responsive { display: none !important; }
   .mobile-dropdown { display: block !important; }
 }
@@ -1054,7 +1054,7 @@ input[type="number"] {
 .mobile-only { display: none; }
 .desktop-only { display: flex; }
 
-@media (width <= calc(var(--collapse-threshold) - 1px)) {
+@media (max-width: calc(var(--collapse-threshold) - 1px)) {
   .mobile-only { display: block !important; }
   .desktop-only { display: none !important; }
 }


### PR DESCRIPTION
## Summary

- `stylelint-config-standard` 40 auto-fixed `max-width: calc(var(...))` → `width <= calc(var(...))` (range notation) during the bulk dep bump
- `autoprefixer` / `@tailwindcss/postcss` cannot parse `calc(var(...))` inside CSS range media query syntax → build error on dev server

**Fix:** revert the two `--collapse-threshold` media queries back to `max-width:` notation and add `"media-feature-range-notation": null` to `.stylelintrc.json` so the rule doesn't re-introduce the pattern.

Plain pixel-value range queries (`width <= 540px` etc.) are unaffected — autoprefixer handles those fine.

## Test plan
- [x] Dev server starts without build error
- [x] Home page and Dice Roller render correctly
- [x] `pnpm run lint:css` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)