### PR TITLE
fix(build): resolve TypeScript 6 and CSS errors blocking CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -41,12 +41,13 @@ jobs:
       run: pnpm --filter frontend test
 
     - name: Upload frontend coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         # vitest outputs lcov to frontend/coverage/lcov.info when run from frontend dir
         files: frontend/coverage/lcov.info
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
+        slug: Ch3fUlrich/Tools
 
     - name: Upload frontend coverage artifact (fallback)
       if: success()

--- a/frontend/__tests__/auth_components_additional.test.tsx
+++ b/frontend/__tests__/auth_components_additional.test.tsx
@@ -118,7 +118,7 @@ describe('AuthModal and AuthContext', () => {
   it('handles localStorage errors gracefully', async () => {
     // Make the custom localStorage mock throw on setItem
     const originalImpl = localStorage.setItem;
-    localStorage.setItem.mockImplementationOnce(() => {
+    (localStorage.setItem as any).mockImplementationOnce(() => {
       throw new Error('Storage quota exceeded');
     });
 
@@ -147,7 +147,7 @@ describe('AuthModal and AuthContext', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith('Could not persist auth_user:', expect.any(Error));
 
     // Restore mocks
-    localStorage.setItem.mockImplementation(originalImpl);
+    (localStorage.setItem as any).mockImplementation(originalImpl);
     consoleWarnSpy.mockRestore();
   });
 

--- a/frontend/__tests__/bloodlevel_calculator.test.tsx
+++ b/frontend/__tests__/bloodlevel_calculator.test.tsx
@@ -55,7 +55,7 @@ describe('BloodLevelCalculator (consolidated)', () => {
   it('covers branches: loaded substances, error handling and interactions', async () => {
     // Branch: loaded substances and chart title appears
     const getSub = vi.spyOn(api, 'getToleranceSubstances').mockResolvedValueOnce([{ id: 's1', name: 'Sub', halfLifeHours: 2 }]);
-    const calc = vi.spyOn(api, 'calculateTolerance').mockResolvedValueOnce({ blood_levels: [{ time: 't', substance: 'Sub', amountMg: 5 }] });
+    const calc = vi.spyOn(api, 'calculateTolerance').mockResolvedValueOnce({ blood_levels: [{ time: 't', substance: 'Sub', amount_mg: 5 }] });
 
     const { container: c1 } = render(<TestWrapper><BloodLevelCalculator /></TestWrapper>);
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -443,7 +443,7 @@ html, body, #__next {
   transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-@container (max-width: calc(var(--label-threshold) - 1px)) {
+@container (max-width: 89px) {
   .nav-label { display: none; }
   .nav-emoji { display: inline; }
 }

--- a/frontend/components/icons/DiceIcon.tsx
+++ b/frontend/components/icons/DiceIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-export const DiceIcon: React.FC<{ className?: string }> = ({ className = 'w-4 h-4 text-gray-900 dark:text-white' }) => (
-  <svg className={className} viewBox="0 0 22 22" fill="currentColor" width="36" height="36">
+export const DiceIcon: React.FC<{ className?: string; style?: React.CSSProperties }> = ({ className = 'w-4 h-4 text-gray-900 dark:text-white', style }) => (
+  <svg className={className} style={style} viewBox="0 0 22 22" fill="currentColor" width="36" height="36">
     <path d="M 0 0 L 0 22 L 22 22 L 22 0 L 0 0 z M 2 2 L 20 2 L 20 20 L 2 20 L 2 2 z M 6 3 A 2 2 0 0 0 6 7 A 2 2 0 0 0 6 3 z M 16 3 A 2 2 0 0 0 16 7 A 2 2 0 0 0 16 3 z M 6 9 A 2 2 0 0 0 6 13 A 2 2 0 0 0 6 9 z M 16 9 A 2 2 0 0 0 16 13 A 2 2 0 0 0 16 9 z M 6 15 A 2 2 0 0 0 6 19 A 2 2 0 0 0 6 15 z M 16 15 A 2 2 0 0 0 16 19 A 2 2 0 0 0 16 15 z"/>
   </svg>
 );

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,6 +22,7 @@
         "name": "next"
       }
     ],
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary

Fixes the CI failures introduced by TypeScript 6 and stylelint-config-standard 40 upgrades.

**TypeScript 6 fixes:**
- `DiceIcon`: add `style?: React.CSSProperties` to props (used in DiceHistory with `style={{ color: 'var(--accent)' }}`)
- `tsconfig.json`: add `"ignoreDeprecations": "6.0"` — TypeScript 6 deprecated `baseUrl` (required by Next.js `@/*` path alias until Next.js migrates)
- `auth_components_additional.test`: cast `localStorage.setItem as any` for vi mock methods (TypeScript 6 is stricter about mock spy types)
- `bloodlevel_calculator.test`: fix mock data to use `amount_mg` (snake_case) not `amountMg` — matches the `BloodLevelPoint` interface

**CSS fix:**
- Replace `@container (max-width: calc(var(--label-threshold) - 1px))` with hardcoded `89px` — PostCSS/autoprefixer cannot resolve `calc(var(...))` inside container queries

**Codecov fix:**
- Bump `codecov-action` from v4 → v5 with explicit `slug` field

> **Note:** The Codecov badge will remain "unknown" until a `CODECOV_TOKEN` secret is added to the repo settings (Settings → Secrets → Actions). Codecov v4+ requires a token even for public repos. Get it from https://codecov.io after connecting the repo.

## Test plan
- [x] `pnpm test --run` — 155/155 pass
- [x] `pnpm run lint` — ESLint 10 clean (0 errors, 0 warnings)
- [x] `pnpm run lint:css` — stylelint 17 clean
- [x] `tsc --noEmit` — TypeScript 6 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)