### PR TITLE
fix(ui): improve mobile tool layouts

### DIFF
--- a/frontend/__tests__/n26analyzer.test.tsx
+++ b/frontend/__tests__/n26analyzer.test.tsx
@@ -104,7 +104,7 @@ describe('N26Analyzer', () => {
     expect(screen.getByText('+150.75 €')).toBeInTheDocument();
 
     // Check category totals - look for Food in the category totals section
-    const categoryTotalsSection = screen.getByText('Category Totals').closest('div');
+    const categoryTotalsSection = screen.getByText('Category Totals').closest('.resizable-card');
     expect(categoryTotalsSection).toHaveTextContent('Food');
     expect(categoryTotalsSection).toHaveTextContent('-45.50 €');
     expect(categoryTotalsSection).toHaveTextContent('Transport');

--- a/frontend/__tests__/timeline_builder.test.tsx
+++ b/frontend/__tests__/timeline_builder.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import TimelineBuilder from '@/components/tools/TimelineBuilder';
 
@@ -6,7 +6,7 @@ vi.mock('@/lib/api/client', () => ({}));
 
 describe('TimelineBuilder', () => {
   it('splits the standalone timeline editor into timeline and settings cards', () => {
-    render(<TimelineBuilder />);
+    const { container } = render(<TimelineBuilder />);
 
     expect(screen.getByRole('heading', { name: 'Timeline' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Timeline Settings Table' })).toBeInTheDocument();
@@ -18,7 +18,11 @@ describe('TimelineBuilder', () => {
     expect(settingsFrame).toBeInTheDocument();
     expect(timelineFrame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'));
     expect(settingsFrame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'));
-    expect(screen.getAllByRole('button', { name: 'Default' })).toHaveLength(2);
+    expect(container.querySelector('.timeline-figure-card > div[aria-label="Timeline size presets"]')).not.toBeInTheDocument();
+    const timelineSettings = screen.getByLabelText('Timeline settings');
+    fireEvent.click(timelineSettings);
+    expect(timelineSettings.parentElement).toHaveAttribute('open');
+    expect(screen.getAllByRole('button', { name: 'Default' })).toHaveLength(1);
     expect(screen.getByRole('button', { name: 'Resize Timeline right edge' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Resize Timeline Settings Table bottom edge' })).toBeInTheDocument();
   });

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -185,6 +185,90 @@ html, body, #__next {
   max-width: none;
 }
 
+.resizable-card {
+  max-width: 100%;
+}
+
+.resizable-card[data-has-explicit-size="true"] {
+  width: var(--card-width);
+  max-width: none;
+}
+
+.resizable-card__body[data-has-explicit-height="true"] {
+  height: var(--card-body-height);
+  min-height: var(--card-body-min-height);
+  max-height: var(--card-body-max-height);
+  overflow: auto;
+}
+
+.resizable-card-header {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.resizable-card-title {
+  min-width: 0;
+  margin: 0;
+}
+
+.resizable-card-settings {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.resizable-card-settings__trigger {
+  color: var(--muted);
+  border-color: var(--input-border);
+  background: var(--input-bg);
+  cursor: pointer;
+  list-style: none;
+}
+
+.resizable-card-settings__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.resizable-card-settings__trigger:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+
+.resizable-card-settings[open] .resizable-card-settings__trigger {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+
+.resizable-card-settings__panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 30;
+  width: min(16rem, calc(100vw - 3rem));
+  padding: 0.75rem;
+}
+
+.resizable-card-settings__label {
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.resizable-card-settings__presets {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+
+.resizable-card-settings__preset {
+  justify-content: flex-start;
+}
+
 .header-container {
   max-width: 72rem;
   margin-left: auto;
@@ -358,6 +442,38 @@ html, body, #__next {
 .resize-handle-sw {
   bottom: -5px;
   left: -5px;
+}
+
+.bloodlevel-intake-table {
+  overflow-x: auto;
+}
+
+.bloodlevel-intake-table table {
+  min-width: 760px;
+}
+
+.bloodlevel-chart {
+  width: 100%;
+  overflow: hidden;
+}
+
+.timeline-builder-shell {
+  width: 100%;
+}
+
+.timeline-embed-frame {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+}
+
+.timeline-figure-card .resizable-card__body[data-has-explicit-height="true"] {
+  overflow: hidden;
+}
+
+.timeline-settings-card .resizable-card__body[data-has-explicit-height="true"] {
+  overflow: hidden;
 }
 
 /* Enhanced Buttons with modern design */
@@ -1230,6 +1346,15 @@ input[type="number"] {
     padding-left: 1rem;
     padding-right: 1rem;
   }
+
+  .tool-page-main,
+  .tool-page-frame,
+  .tool-page-main:has(.resizable-card[data-has-explicit-size="true"]),
+  .tool-page-frame:has(.resizable-card[data-has-explicit-size="true"]) {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
   
   .header-container {
     padding-left: 1rem;
@@ -1244,6 +1369,110 @@ input[type="number"] {
   .card {
     padding: 1.25rem;
     border-radius: 0.75rem;
+  }
+
+  .resizable-card[data-has-explicit-size="true"] {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .resizable-card__body[data-has-explicit-height="true"] {
+    height: auto;
+    min-height: 0;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .resizable-card .resize-handle {
+    display: none;
+  }
+
+  .bloodlevel-tool {
+    padding: 0.75rem;
+  }
+
+  .bloodlevel-intake-table {
+    overflow: visible;
+  }
+
+  .bloodlevel-intake-table table,
+  .bloodlevel-intake-table tbody,
+  .bloodlevel-intake-table tr,
+  .bloodlevel-intake-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .bloodlevel-intake-table table {
+    min-width: 0;
+    border: 0 !important;
+  }
+
+  .bloodlevel-intake-table thead {
+    display: none;
+  }
+
+  .bloodlevel-intake-table tr {
+    margin-bottom: 0.875rem;
+    padding: 0.9rem;
+    border: 1px solid var(--card-border) !important;
+    border-radius: 0.75rem;
+    background: var(--input-bg);
+  }
+
+  .bloodlevel-intake-table td {
+    padding: 0.45rem 0 !important;
+    border: 0;
+  }
+
+  .bloodlevel-intake-table td::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .bloodlevel-actions-cell {
+    padding-top: 0.75rem !important;
+  }
+
+  .bloodlevel-actions-cell::before {
+    display: none !important;
+  }
+
+  .bloodlevel-actions-cell .remove-btn {
+    width: 100%;
+    min-height: 2.5rem;
+  }
+
+  .bloodlevel-empty-state {
+    padding: 2rem 1rem;
+  }
+
+  .timeline-builder-shell {
+    padding: 0.75rem;
+  }
+
+  .timeline-builder-shell .resizable-card h2 {
+    font-size: 1.125rem;
+    line-height: 1.35;
+  }
+
+  .timeline-figure-card .resizable-card__body[data-has-explicit-height="true"],
+  .timeline-settings-card .resizable-card__body[data-has-explicit-height="true"] {
+    overflow: visible;
+  }
+
+  .timeline-embed-frame--figure {
+    height: clamp(680px, 174vw, 860px);
+    min-height: clamp(680px, 174vw, 860px);
+  }
+
+  .timeline-embed-frame--settings {
+    height: clamp(1200px, 240vh, 2000px);
+    min-height: clamp(1200px, 240vh, 2000px);
   }
   
   .tool-card {

--- a/frontend/components/charts/LineChart.tsx
+++ b/frontend/components/charts/LineChart.tsx
@@ -24,7 +24,7 @@ export const LineChart: React.FC<LineChartProps> = ({
 }) => {
   if (!data || data.length === 0) {
     return (
-      <div className={`flex items-center justify-center text-gray-900 dark:text-white ${className}`} style={{ width, height }}>
+      <div className={`flex items-center justify-center text-gray-900 dark:text-white ${className}`} style={{ width: '100%', maxWidth: width, height }}>
         <p className="text-gray-500 dark:text-gray-400">No data to display</p>
       </div>
     );
@@ -41,7 +41,7 @@ export const LineChart: React.FC<LineChartProps> = ({
 
   if (validData.length === 0) {
     return (
-      <div className={`flex items-center justify-center text-gray-900 dark:text-white ${className}`} style={{ width, height }}>
+      <div className={`flex items-center justify-center text-gray-900 dark:text-white ${className}`} style={{ width: '100%', maxWidth: width, height }}>
         <p className="text-gray-500 dark:text-gray-400">No valid data to display</p>
       </div>
     );
@@ -115,7 +115,13 @@ export const LineChart: React.FC<LineChartProps> = ({
           {title}
         </h3>
       )}
-  <svg width={width} height={height} className="border border-gray-200 dark:border-gray-700 rounded text-gray-600 dark:text-gray-400">
+  <svg
+    width={width}
+    height={height}
+    viewBox={`0 0 ${width} ${height}`}
+    className="border border-gray-200 dark:border-gray-700 rounded text-gray-600 dark:text-gray-400"
+    style={{ width: '100%', maxWidth: width, height: 'auto', display: 'block' }}
+  >
         {/* Grid lines */}
         {xTicks.map((tick, i) => (
           <line

--- a/frontend/components/tools/BloodLevelCalculator.tsx
+++ b/frontend/components/tools/BloodLevelCalculator.tsx
@@ -103,13 +103,13 @@ const BloodLevelCalculator: React.FC = () => {
   };
 
   return (
-    <div className="p-6 lg:p-8 space-y-8">
+    <div className="bloodlevel-tool p-4 sm:p-6 lg:p-8 space-y-6 lg:space-y-8">
       {/* Input Panel */}
       <CardSection title="Substance Intake" gradient="from-red-500 to-rose-600" delay="100ms">
 
         <div className="space-y-4">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm rounded-lg min-w-[760px]" style={{ border: '1px solid var(--card-border)' }}>
+          <div className="bloodlevel-intake-table">
+            <table className="w-full text-sm rounded-lg" style={{ border: '1px solid var(--card-border)' }}>
               <thead>
                 <tr style={{ background: 'var(--input-bg)' }}>
                   <th className="px-3 py-2 text-left text-xs font-medium" style={{ color: 'var(--muted)' }}>Substance</th>
@@ -123,8 +123,9 @@ const BloodLevelCalculator: React.FC = () => {
               <tbody>
                 {intakes.map((intake, index) => (
                   <tr key={index} style={{ borderTop: '1px solid var(--card-border)' }}>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2" data-label="Substance">
                       <select
+                        aria-label={`Substance for intake ${index + 1}`}
                         value={intake.substance}
                         onChange={(e) => updateIntake(index, { substance: e.target.value })}
                         className="form-input text-sm"
@@ -137,16 +138,18 @@ const BloodLevelCalculator: React.FC = () => {
                         ))}
                       </select>
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2" data-label="Time">
                       <input
+                        aria-label={`Time for intake ${index + 1}`}
                         type="datetime-local"
                         value={intake.time.slice(0, 16)}
                         onChange={(e) => updateIntake(index, { time: new Date(e.target.value).toISOString() })}
                         className="form-input text-sm"
                       />
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2" data-label="Type">
                       <select
+                        aria-label={`Intake type for intake ${index + 1}`}
                         value={intake.intakeType}
                         onChange={(e) => updateIntake(index, { intakeType: e.target.value })}
                         className="form-input text-sm"
@@ -157,8 +160,9 @@ const BloodLevelCalculator: React.FC = () => {
                         <option value="topical">Topical</option>
                       </select>
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2" data-label="After meal">
                       <NumberInput
+                        id={`time-after-meal-${index}`}
                         value={intake.timeAfterMeal ? String(intake.timeAfterMeal) : ''}
                         onChange={(v) => updateIntake(index, { timeAfterMeal: v ? Number(v) : null })}
                         step={1}
@@ -167,8 +171,9 @@ const BloodLevelCalculator: React.FC = () => {
                         className="form-input--compact"
                       />
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2" data-label="Dosage">
                       <NumberInput
+                        id={`dosage-${index}`}
                         value={String(intake.dosageMg)}
                         onChange={(v) => updateIntake(index, { dosageMg: Number(v) })}
                         step={0.1}
@@ -177,7 +182,7 @@ const BloodLevelCalculator: React.FC = () => {
                         className="form-input--compact"
                       />
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2 bloodlevel-actions-cell" data-label="Actions">
                       {intakes.length > 1 && (
                         <button
                           type="button"
@@ -248,7 +253,7 @@ const BloodLevelCalculator: React.FC = () => {
                     width={400}
                     height={200}
                     color="#3b82f6"
-                    className="w-full"
+                    className="bloodlevel-chart"
                   />
                 </div>
               );
@@ -277,7 +282,7 @@ const BloodLevelCalculator: React.FC = () => {
             </div>
           </div>
         ) : (
-          <div className="rounded-xl p-12 flex items-center justify-center" style={{ background: 'var(--input-bg)' }}>
+          <div className="bloodlevel-empty-state rounded-xl p-12 flex items-center justify-center" style={{ background: 'var(--input-bg)' }}>
             <div className="text-center">
               <span className="text-5xl mb-4 block">📊</span>
               <p className="text-sm" style={{ color: 'var(--muted)' }}>

--- a/frontend/components/tools/TimelineBuilder.tsx
+++ b/frontend/components/tools/TimelineBuilder.tsx
@@ -18,10 +18,12 @@ const settingsPresets: CardSizePreset[] = [
 ];
 
 const settingsDefaultSize = { width: 1280, height: 1860 };
+const initialTimelineSrc = '../timeline/timeline.html?panel=timeline&theme=light';
+const initialSettingsSrc = '../timeline/timeline.html?panel=settings&theme=light';
 
 export default function TimelineBuilder() {
-  const [timelineSrc, setTimelineSrc] = useState('about:blank');
-  const [settingsSrc, setSettingsSrc] = useState('about:blank');
+  const [timelineSrc, setTimelineSrc] = useState(process.env.NODE_ENV === 'test' ? 'about:blank' : initialTimelineSrc);
+  const [settingsSrc, setSettingsSrc] = useState(process.env.NODE_ENV === 'test' ? 'about:blank' : initialSettingsSrc);
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
 
   useEffect(() => {
@@ -50,19 +52,20 @@ export default function TimelineBuilder() {
   }, [theme]);
 
   return (
-    <div className="p-4 sm:p-6 lg:p-8 space-y-6">
+    <div className="timeline-builder-shell p-3 sm:p-6 lg:p-8 space-y-4 sm:space-y-6">
       <ResizableCardSection
         title="Timeline"
         gradient="from-cyan-400 to-teal-500"
         presets={timelinePresets}
         defaultSize={timelineDefaultSize}
-        className="mx-auto"
+        className="timeline-figure-card mx-auto"
+        bodyClassName="timeline-embed-body timeline-embed-body--figure"
         delay="100ms"
       >
         <iframe
           title="Timeline builder preview"
           src={timelineSrc}
-          className="block w-full h-full"
+          className="timeline-embed-frame timeline-embed-frame--figure block w-full h-full"
           style={{
             border: 0,
             background: 'transparent',
@@ -77,13 +80,14 @@ export default function TimelineBuilder() {
         presets={settingsPresets}
         defaultSize={settingsDefaultSize}
         maxHeight={3200}
-        className="mx-auto"
+        className="timeline-settings-card mx-auto"
+        bodyClassName="timeline-embed-body timeline-embed-body--settings"
         delay="200ms"
       >
         <iframe
           title="Timeline builder settings table"
           src={settingsSrc}
-          className="block w-full h-full"
+          className="timeline-embed-frame timeline-embed-frame--settings block w-full h-full"
           style={{
             border: 0,
             background: 'transparent',

--- a/frontend/components/ui/ResizableCardSection.tsx
+++ b/frontend/components/ui/ResizableCardSection.tsx
@@ -23,6 +23,7 @@ interface Props {
   minHeight?: number;
   maxHeight?: number;
   className?: string;
+  bodyClassName?: string;
   delay?: string;
 }
 
@@ -36,10 +37,13 @@ export default function ResizableCardSection({
   minHeight = 360,
   maxHeight = 2600,
   className = '',
+  bodyClassName = '',
   delay,
 }: Props) {
   const cardRef = useRef<globalThis.HTMLDivElement>(null);
+  const settingsRef = useRef<globalThis.HTMLDetailsElement>(null);
   const [size, setSize] = useState<Partial<CardSize>>(defaultSize ?? {});
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const startResize = useCallback((edge: ResizeEdge, event: React.PointerEvent) => {
     event.preventDefault();
@@ -96,29 +100,63 @@ export default function ResizableCardSection({
       className={`card resizable-card animate-fade-in-up ${className}`}
       style={{
         animationDelay: delay,
-        width: size.width ? `${size.width}px` : undefined,
-        maxWidth: size.width ? 'none' : '100%',
+        '--card-width': size.width ? `${size.width}px` : undefined,
         position: 'relative',
-      }}
+      } as React.CSSProperties}
     >
-      <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-3">
-        <div className={`w-1 h-8 bg-gradient-to-b ${gradient} rounded-full flex-shrink-0`} aria-hidden="true" />
-        {title}
-      </h2>
-      <div className="mb-6 flex flex-wrap gap-2" aria-label={`${title} size presets`}>
-        {presets.map((preset) => (
-          <button
-            key={preset.label}
-            type="button"
-            className="btn-ghost px-3 py-2 text-sm"
-            onClick={() => setSize({ width: preset.width, height: preset.height })}
+      <div className="resizable-card-header">
+        <h2 className="resizable-card-title text-xl font-semibold text-slate-900 dark:text-white flex items-center gap-3">
+          <div className={`w-1 h-8 bg-gradient-to-b ${gradient} rounded-full flex-shrink-0`} aria-hidden="true" />
+          {title}
+        </h2>
+        <details
+          className="resizable-card-settings"
+          ref={settingsRef}
+          onToggle={(event) => setSettingsOpen(event.currentTarget.open)}
+        >
+          <summary
+            className="btn-icon resizable-card-settings__trigger"
+            aria-label={`${title} settings`}
+            title={`${title} settings`}
           >
-            {preset.label}
-          </button>
-        ))}
+            <svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" style={{ width: 18, height: 18, flexShrink: 0 }}>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.3 4.3c.4-1.7 3-1.7 3.4 0 .2.9 1.2 1.4 2 1 .1 0 .3-.1.4-.2 1.5-.8 3.3 1 2.5 2.5-.5.8-.1 1.9.9 2.1 1.7.4 1.7 3 0 3.4-.9.2-1.4 1.2-1 2 .1.1.1.3.2.4.8 1.5-1 3.3-2.5 2.5-.8-.5-1.9-.1-2.1.9-.4 1.7-3 1.7-3.4 0-.2-.9-1.2-1.4-2-1-.1 0-.3.1-.4.2-1.5.8-3.3-1-2.5-2.5.5-.8.1-1.9-.9-2.1-1.7-.4-1.7-3 0-3.4.9-.2 1.4-1.2 1-2-.1-.1-.1-.3-.2-.4-.8-1.5 1-3.3 2.5-2.5.8.5 1.9.1 2.1-.9Z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9a3 3 0 1 1 0 6 3 3 0 0 1 0-6Z" />
+            </svg>
+          </summary>
+          {settingsOpen && (
+            <div className="popup-panel resizable-card-settings__panel animate-scale-in">
+              <div className="resizable-card-settings__label">Card size</div>
+              <div className="resizable-card-settings__presets" aria-label={`${title} size presets`}>
+                {presets.map((preset) => (
+                  <button
+                    key={preset.label}
+                    type="button"
+                    className="btn-ghost resizable-card-settings__preset px-3 py-2 text-sm"
+                    onClick={() => {
+                      setSize({ width: preset.width, height: preset.height });
+                      setSettingsOpen(false);
+                      settingsRef.current?.removeAttribute('open');
+                    }}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </details>
       </div>
 
-      <div style={size.height ? { height: `${size.height}px`, minHeight, overflow: 'auto' } : undefined}>
+      <div
+        className={`resizable-card__body ${bodyClassName}`}
+        data-has-explicit-height={size.height ? 'true' : undefined}
+        style={{
+          '--card-body-height': size.height ? `${size.height}px` : undefined,
+          '--card-body-min-height': `${minHeight}px`,
+          '--card-body-max-height': `${maxHeight}px`,
+        } as React.CSSProperties}
+      >
         {children}
       </div>
 

--- a/frontend/public/timeline/src/editor/timeline-editor.js
+++ b/frontend/public/timeline/src/editor/timeline-editor.js
@@ -5713,11 +5713,11 @@
       const xLabel = row.xLabel || roundToThree(row.x);
 
       tr.innerHTML = `
-        <td><span class="inspector-kind ${kindClass}">${escapeHtml(row.kind)}</span></td>
-        <td>${escapeHtml(row.group)}</td>
-        <td>${escapeHtml(row.label)}</td>
-        <td>${escapeHtml(xLabel)}</td>
-        <td>${escapeHtml(yLabel)}</td>
+        <td data-label="Type"><span class="inspector-kind ${kindClass}">${escapeHtml(row.kind)}</span></td>
+        <td data-label="Group">${escapeHtml(row.group)}</td>
+        <td data-label="Label">${escapeHtml(row.label)}</td>
+        <td data-label="Age / Start">${escapeHtml(xLabel)}</td>
+        <td data-label="Y / End age / Width">${escapeHtml(yLabel)}</td>
       `;
 
       state.ui.inspectorBody.appendChild(tr);

--- a/frontend/public/timeline/style/timeline.css
+++ b/frontend/public/timeline/style/timeline.css
@@ -1307,3 +1307,100 @@ html[data-embed-panel="settings"] .timeline-inspector h2 {
 html[data-embed-panel="settings"] .inspector-table-wrap {
   max-height: none;
 }
+
+@media (max-width: 640px) {
+  html[data-embed-panel="timeline"] .timeline-usage {
+    display: none;
+  }
+
+  html[data-embed-panel="timeline"] .timeline-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 12px;
+  }
+
+  html[data-embed-panel="timeline"] .timeline-toolbar-actions,
+  html[data-embed-panel="timeline"] .timeline-add-actions,
+  html[data-embed-panel="timeline"] .timeline-view-actions,
+  html[data-embed-panel="timeline"] .timeline-export-actions {
+    justify-content: flex-start;
+    gap: 8px;
+  }
+
+  html[data-embed-panel="timeline"] .timeline-add-actions .editor-btn,
+  html[data-embed-panel="timeline"] .timeline-view-actions .editor-btn,
+  html[data-embed-panel="timeline"] .timeline-export-actions .editor-btn {
+    min-height: 34px;
+    padding: 6px 9px;
+  }
+
+  html[data-embed-panel="timeline"] .timeline-scroller {
+    overflow: visible;
+    padding: 0;
+  }
+
+  html[data-embed-panel="timeline"] .timeline-svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  html[data-embed-panel="timeline"] .legend-strip {
+    padding: 8px 0 10px;
+    overflow: visible;
+  }
+
+  html[data-embed-panel="settings"] .inspector-add-controls,
+  html[data-embed-panel="settings"] .inspector-controls {
+    grid-template-columns: 1fr;
+  }
+
+  html[data-embed-panel="settings"] .inspector-table-wrap {
+    overflow: visible;
+  }
+
+  html[data-embed-panel="settings"] .inspector-table,
+  html[data-embed-panel="settings"] .inspector-table tbody,
+  html[data-embed-panel="settings"] .inspector-table tr,
+  html[data-embed-panel="settings"] .inspector-table td {
+    display: block;
+    width: 100%;
+  }
+
+  html[data-embed-panel="settings"] .inspector-table thead {
+    display: none;
+  }
+
+  html[data-embed-panel="settings"] .inspector-table tr {
+    margin-bottom: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--divider);
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--surface-2) 70%, transparent);
+  }
+
+  html[data-embed-panel="settings"] .inspector-table td {
+    padding: 6px 0;
+    border-bottom: 0;
+  }
+
+  html[data-embed-panel="settings"] .inspector-table td::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 4px;
+    color: var(--muted);
+    font-size: var(--text-xs);
+    font-weight: 700;
+  }
+
+  html[data-embed-panel="settings"] .inspector-expand {
+    padding: 0;
+    border: 0;
+    background: transparent;
+  }
+
+  html[data-embed-panel="settings"] .inspector-expand td::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary\n- improve phone layouts for timeline and blood level tools\n- add shared resizable card settings menu for size presets\n- keep timeline toolbar and figure visible on narrow screens\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --filter frontend run lint\n- pnpm --filter frontend run lint:css\n- pnpm --filter frontend test --run\n- pnpm --filter frontend run build\n- docker rust fmt + clippy\n- docker backend tests with Postgres/Redis\n- headless Chrome timeline settings check