### PR TITLE
fix(ci): avoid dependabot auto-approval failure

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -20,9 +21,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-approve low-risk Dependabot PRs
+      - name: Mark low-risk Dependabot PRs for automerge
         if: contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type)
-        run: gh pr review --approve "$PR_URL" --body "Auto-approved low-risk $UPDATE_TYPE dependency update."
+        run: gh pr comment "$PR_URL" --body "Low-risk $UPDATE_TYPE dependency update detected. Auto-merge has been enabled and will merge after required checks and reviews pass."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}


### PR DESCRIPTION
## Summary\n- remove the prohibited GitHub Actions pull request approval call from the Dependabot automerge workflow\n- add issues permission and leave a safe comment for low-risk updates instead\n- keep auto-merge enabled for semver patch/minor Dependabot PRs\n\n## Root cause\nGitHub Actions cannot approve pull requests with the default GITHUB_TOKEN, so gh pr review --approve fails with GitHub Actions is not permitted to approve pull requests.\n\n## Verification\n- inspected failing Automerge Dependabot run logs\n- enumerated remote Dependabot branches older than 16 hours\n- git diff --check\n- parsed workflow YAML with PyYAML