### PR TITLE
feat: backend auto-detection with local fallback, UI fixes, timeline rework

### DIFF
--- a/backend/src/tools/bloodlevel.rs
+++ b/backend/src/tools/bloodlevel.rs
@@ -118,7 +118,9 @@ pub fn find_substance_by_name<'a>(
     name: &str,
     substances: &'a [Substance],
 ) -> Option<&'a Substance> {
-    substances.iter().find(|s| s.name.to_lowercase() == name.to_lowercase())
+    // The frontend sends substance ids (e.g. "alcohol"); accept display names
+    // too so older clients keep working.
+    substances.iter().find(|s| s.id.eq_ignore_ascii_case(name) || s.name.eq_ignore_ascii_case(name))
 }
 
 pub fn calculate_blood_levels(request: ToleranceRequest) -> Result<ToleranceResponse, String> {

--- a/frontend/__tests__/backend_fallback.test.ts
+++ b/frontend/__tests__/backend_fallback.test.ts
@@ -1,0 +1,123 @@
+import {
+  checkBackend,
+  getBackendStatus,
+  markBackendOffline,
+  markBackendOnline,
+  subscribeBackendStatus,
+  resetBackendStatusForTests,
+} from '../lib/api/backendStatus';
+import { rollDice, calculateFatLoss, getToleranceSubstances, analyzeN26Data } from '../lib/api/client';
+
+describe('backendStatus', () => {
+  beforeEach(() => {
+    resetBackendStatusForTests();
+    (globalThis as any).fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    resetBackendStatusForTests();
+  });
+
+  it('starts unknown, probes /api/health and reports online', async () => {
+    (globalThis as any).fetch.mockResolvedValueOnce({ ok: true });
+    expect(getBackendStatus()).toBe('unknown');
+    await expect(checkBackend()).resolves.toBe(true);
+    expect(getBackendStatus()).toBe('online');
+    expect((globalThis as any).fetch).toHaveBeenCalledWith('/api/health', expect.anything());
+  });
+
+  it('reports offline when the probe fails and notifies subscribers', async () => {
+    (globalThis as any).fetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+    const listener = vi.fn();
+    const unsubscribe = subscribeBackendStatus(listener);
+    await expect(checkBackend()).resolves.toBe(false);
+    expect(getBackendStatus()).toBe('offline');
+    expect(listener).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('caches the result instead of probing every call', async () => {
+    (globalThis as any).fetch.mockResolvedValue({ ok: true });
+    await checkBackend();
+    await checkBackend();
+    await checkBackend();
+    expect((globalThis as any).fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one in-flight probe across concurrent callers', async () => {
+    (globalThis as any).fetch.mockResolvedValue({ ok: true });
+    await Promise.all([checkBackend(), checkBackend(), checkBackend()]);
+    expect((globalThis as any).fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('client fallback to local computation', () => {
+  beforeEach(() => {
+    resetBackendStatusForTests();
+    (globalThis as any).fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    resetBackendStatusForTests();
+  });
+
+  it('falls back to local dice rolling on network failure', async () => {
+    (globalThis as any).fetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+    const res = (await rollDice({ die: { type: 'd6' }, count: 3 })) as {
+      rolls: { used: number[] }[];
+    };
+    expect(res.rolls[0].used).toHaveLength(3);
+    expect(getBackendStatus()).toBe('offline');
+  });
+
+  it('skips the network entirely once offline (fast path)', async () => {
+    markBackendOffline();
+    const res = await calculateFatLoss({ kcal_deficit: 7000, weight_loss_kg: 1 });
+    expect(res.is_valid).toBe(true);
+    expect(res.fat_loss_percentage).toBeCloseTo(100, 6);
+    // Only the background health re-probe may touch fetch — never the tool endpoint.
+    const calls = ((globalThis as any).fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.every(([url]: [string]) => String(url).includes('/api/health'))).toBe(true);
+  });
+
+  it('does NOT fall back on backend HTTP errors', async () => {
+    markBackendOnline();
+    (globalThis as any).fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'bad request',
+    });
+    await expect(calculateFatLoss({ kcal_deficit: 0, weight_loss_kg: 0 })).rejects.toThrow(
+      /Failed to calculate fat loss/,
+    );
+    expect(getBackendStatus()).toBe('online');
+  });
+
+  it('serves the local substance list offline', async () => {
+    markBackendOffline();
+    const subs = await getToleranceSubstances();
+    expect(subs.map((s) => s.id)).toContain('caffeine');
+  });
+
+  it('analyzes N26 data locally offline', async () => {
+    markBackendOffline();
+    const res = await analyzeN26Data({
+      data: { bankTransfers: [{ amount: 5, ts: '2024-01-01', reference_text: 'x' }] },
+    });
+    expect(res.overall_total).toBeCloseTo(5);
+  });
+
+  it('marks the backend online again after a successful call', async () => {
+    markBackendOnline();
+    (globalThis as any).fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ fat_loss_percentage: 50, muscle_loss_percentage: 50, is_valid: true }),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+    const res = await calculateFatLoss({ kcal_deficit: 4100, weight_loss_kg: 1 });
+    expect(res.is_valid).toBe(true);
+    expect(getBackendStatus()).toBe('online');
+  });
+});

--- a/frontend/__tests__/bloodlevel_calculator.test.tsx
+++ b/frontend/__tests__/bloodlevel_calculator.test.tsx
@@ -42,8 +42,8 @@ describe('BloodLevelCalculator (consolidated)', () => {
   expect(selects.length).toBeGreaterThan(0);
   fireEvent.change(selects[0], { target: { value: 'TestSub' } });
 
-  const inputs = within(container).getAllByRole('spinbutton');
-  if (inputs.length > 0) fireEvent.change(inputs[0], { target: { value: '10' } });
+  const dosageInputs = within(container).getAllByPlaceholderText('mg');
+  fireEvent.change(dosageInputs[0], { target: { value: '10' } });
 
   const calcBtn = within(container).getByRole('button', { name: /Calculate Blood Levels|calculate blood levels/i });
   fireEvent.click(calcBtn);

--- a/frontend/__tests__/local_compute.test.ts
+++ b/frontend/__tests__/local_compute.test.ts
@@ -1,0 +1,172 @@
+import { calculateFatLossLocal } from '../lib/local/fatLoss';
+import { rollDiceLocal } from '../lib/local/dice';
+import { getSubstancesLocal, calculateToleranceLocal } from '../lib/local/bloodLevel';
+import { analyzeN26DataLocal } from '../lib/local/n26';
+
+describe('local fat loss calculation', () => {
+  it('matches backend formula: 7000 kcal for 1 kg is 100% fat', () => {
+    const res = calculateFatLossLocal({ kcal_deficit: 7000, weight_loss_kg: 1 });
+    expect(res.is_valid).toBe(true);
+    expect(res.fat_loss_percentage).toBeCloseTo(100, 6);
+    expect(res.muscle_loss_percentage).toBeCloseTo(0, 6);
+  });
+
+  it('returns 0% fat when deficit equals muscle energy', () => {
+    const res = calculateFatLossLocal({ kcal_deficit: 2400, weight_loss_kg: 2 });
+    expect(res.is_valid).toBe(true);
+    expect(res.fat_loss_percentage).toBeCloseTo(0, 6);
+    expect(res.muscle_loss_percentage).toBeCloseTo(100, 6);
+  });
+
+  it('rejects non-positive inputs and out-of-range results', () => {
+    expect(calculateFatLossLocal({ kcal_deficit: 0, weight_loss_kg: 1 }).is_valid).toBe(false);
+    expect(calculateFatLossLocal({ kcal_deficit: 3500, weight_loss_kg: -1 }).is_valid).toBe(false);
+    expect(calculateFatLossLocal({ kcal_deficit: 1_000_000, weight_loss_kg: 1 }).is_valid).toBe(false);
+    expect(calculateFatLossLocal({ kcal_deficit: 100, weight_loss_kg: 1 }).is_valid).toBe(false);
+  });
+});
+
+describe('local dice rolling', () => {
+  it('rolls the requested number of dice within range', () => {
+    const res = rollDiceLocal({ die: { type: 'd6' }, count: 10, rolls: 3 });
+    expect(res.rolls).toHaveLength(3);
+    for (const roll of res.rolls) {
+      expect(roll.used).toHaveLength(10);
+      for (const v of roll.used) {
+        expect(v).toBeGreaterThanOrEqual(1);
+        expect(v).toBeLessThanOrEqual(6);
+      }
+      expect(roll.sum).toBe(roll.used.reduce((a, b) => a + b, 0));
+    }
+    expect(res.summary.totalRollsRequested).toBe(3);
+  });
+
+  it('supports custom sides and computes stats', () => {
+    const res = rollDiceLocal({ die: { type: 'custom', sides: 3 }, count: 5 });
+    const roll = res.rolls[0];
+    expect(roll.average).toBeCloseTo(roll.sum / 5);
+    const sorted = [...roll.used].sort((a, b) => a - b);
+    expect(roll.spread).toBe(sorted[4] - sorted[0]);
+    expect(roll.median).toBe(sorted[2]);
+  });
+
+  it('honours rerolls below a threshold', () => {
+    const res = rollDiceLocal({
+      die: { type: 'd6' },
+      count: 20,
+      reroll: { mode: 'lt', threshold: 2, maxRerolls: 100 },
+      maxRerollsPerDie: 100,
+    });
+    // With 100 allowed rerolls, ending on <=2 is (2/6)^101 — practically impossible.
+    for (const v of res.rolls[0].used) {
+      expect(v).toBeGreaterThan(2);
+    }
+    expect(res.rolls[0].perDie.every((d) => d.original.length >= 1)).toBe(true);
+  });
+
+  it('advantage per-die picks the higher of two attempts', () => {
+    const res = rollDiceLocal({ die: { type: 'd20' }, count: 5, advantage: 'adv' });
+    for (const die of res.rolls[0].perDie) {
+      expect(die.original.length).toBe(2);
+      expect(die.final).toBe(Math.max(...die.original));
+    }
+  });
+
+  it('per-set disadvantage picks the lower total', () => {
+    const res = rollDiceLocal({
+      die: { type: 'd6' },
+      count: 4,
+      advantage: 'dis',
+      advantageMode: 'per-set',
+    });
+    expect(res.rolls[0].used).toHaveLength(4);
+  });
+
+  it('enforces backend validation limits with the same messages', () => {
+    expect(() => rollDiceLocal({ die: { type: 'd6' }, count: 0 })).toThrow('count must be > 0');
+    expect(() => rollDiceLocal({ die: { type: 'd6' }, count: 1000 })).toThrow('count exceeds max allowed');
+    expect(() => rollDiceLocal({ die: { type: 'd99' as never }, count: 1 })).toThrow('unknown die type');
+    expect(() => rollDiceLocal({ die: { type: 'custom', sides: 20000 }, count: 1 })).toThrow('sides exceeds max allowed');
+    expect(() => rollDiceLocal({ die: { type: 'd6' }, count: 1, rolls: 101 })).toThrow('too many independent rolls requested');
+  });
+});
+
+describe('local blood level calculation', () => {
+  it('exposes the same five substances as the backend', () => {
+    const subs = getSubstancesLocal();
+    expect(subs.map((s) => s.id)).toEqual(['caffeine', 'nicotine', 'alcohol', 'ibuprofen', 'paracetamol']);
+  });
+
+  it('applies bioavailability and half-life decay', () => {
+    const t0 = '2026-01-01T00:00:00.000Z';
+    const oneHalfLifeLater = '2026-01-01T05:42:00.000Z'; // caffeine t1/2 = 5.7 h
+    const res = calculateToleranceLocal({
+      intakes: [{ substance: 'caffeine', time: t0, intake_type: 'oral', time_after_meal: null, dosage_mg: 100 }],
+      time_points: [t0, oneHalfLifeLater],
+    });
+    expect(res.blood_levels).toHaveLength(2);
+    // At t0: 100 mg * 99% bioavailability.
+    expect(res.blood_levels[0].amount_mg).toBeCloseTo(99, 6);
+    // One half-life later: half remains.
+    expect(res.blood_levels[1].amount_mg).toBeCloseTo(49.5, 6);
+  });
+
+  it('accepts substance ids and display names, skips future intakes', () => {
+    const t0 = '2026-01-01T12:00:00.000Z';
+    const res = calculateToleranceLocal({
+      intakes: [
+        { substance: 'Alcohol (Ethanol)', time: t0, intake_type: 'oral', time_after_meal: null, dosage_mg: 100 },
+        { substance: 'Alcohol (Ethanol)', time: '2026-01-02T00:00:00.000Z', intake_type: 'oral', time_after_meal: null, dosage_mg: 100 },
+      ],
+      time_points: [t0],
+    });
+    expect(res.blood_levels[0].amount_mg).toBeCloseTo(100, 6); // only the past intake counts
+
+    const byId = calculateToleranceLocal({
+      intakes: [{ substance: 'alcohol', time: t0, intake_type: 'oral', time_after_meal: null, dosage_mg: 100 }],
+      time_points: [t0],
+    });
+    expect(byId.blood_levels[0].amount_mg).toBeCloseTo(100, 6);
+  });
+
+  it('throws for unknown substances like the backend', () => {
+    expect(() =>
+      calculateToleranceLocal({
+        intakes: [{ substance: 'unobtainium', time: '2026-01-01T00:00:00Z', intake_type: 'oral', time_after_meal: null, dosage_mg: 1 }],
+        time_points: ['2026-01-01T00:00:00Z'],
+      }),
+    ).toThrow(/not found in database/);
+  });
+});
+
+describe('local N26 analysis', () => {
+  it('processes all three sections like the backend', () => {
+    const res = analyzeN26DataLocal({
+      id: '1',
+      created: '2024-01-01',
+      data: {
+        cash26Data: [{ amount: 10.5, transaction_date: '2024-01-01', transaction_type: 'cash' }],
+        bankTransfers: [{ amount: 100, ts: '2024-01-02', reference_text: 'salary' }],
+        cardTransactions: [
+          { end_amount: 20, transaction_date: '2024-01-03', merchant_name: 'Shop', original_amount: 19.5 },
+        ],
+      },
+    });
+    expect(res.transactions).toHaveLength(3);
+    expect(res.category_totals.cash26Data).toBeCloseTo(10.5);
+    expect(res.category_totals.bankTransfers).toBeCloseTo(100);
+    expect(res.category_totals.cardTransactions).toBeCloseTo(-20);
+    expect(res.overall_total).toBeCloseTo(90.5);
+    expect(res.transactions[2].comment).toBe('Shop: 19.5');
+  });
+
+  it('skips malformed entries and rejects missing data object', () => {
+    const res = analyzeN26DataLocal({
+      data: { cash26Data: [{ amount: 'oops' }, null, 5] },
+    });
+    expect(res.transactions).toHaveLength(0);
+    expect(res.overall_total).toBe(0);
+
+    expect(() => analyzeN26DataLocal({} as Record<string, unknown>)).toThrow(/Invalid N26 data/);
+  });
+});

--- a/frontend/__tests__/timeline_builder.test.tsx
+++ b/frontend/__tests__/timeline_builder.test.tsx
@@ -1,29 +1,23 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import TimelineBuilder from '@/components/tools/TimelineBuilder';
 
 vi.mock('@/lib/api/client', () => ({}));
 
 describe('TimelineBuilder', () => {
-  it('splits the standalone timeline editor into timeline and settings cards', () => {
+  it('embeds the standalone editor once with figure and settings combined', () => {
     const { container } = render(<TimelineBuilder />);
 
-    expect(screen.getByRole('heading', { name: 'Timeline' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Timeline Settings Table' })).toBeInTheDocument();
+    const frame = screen.getByTitle('Timeline editor');
+    expect(frame).toBeInTheDocument();
+    expect(frame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'));
+    expect(frame).toHaveAttribute('sandbox', expect.stringContaining('allow-same-origin'));
 
-    const timelineFrame = screen.getByTitle('Timeline builder preview');
-    const settingsFrame = screen.getByTitle('Timeline builder settings table');
+    // Single embed — the old dual-iframe layout is gone.
+    expect(container.querySelectorAll('iframe')).toHaveLength(1);
 
-    expect(timelineFrame).toBeInTheDocument();
-    expect(settingsFrame).toBeInTheDocument();
-    expect(timelineFrame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'));
-    expect(settingsFrame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'));
-    expect(container.querySelector('.timeline-figure-card > div[aria-label="Timeline size presets"]')).not.toBeInTheDocument();
-    const timelineSettings = screen.getByLabelText('Timeline settings');
-    fireEvent.click(timelineSettings);
-    expect(timelineSettings.parentElement).toHaveAttribute('open');
-    expect(screen.getAllByRole('button', { name: 'Default' })).toHaveLength(1);
-    expect(screen.getByRole('button', { name: 'Resize Timeline right edge' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Resize Timeline Settings Table bottom edge' })).toBeInTheDocument();
+    // The resizable host card and the autosave hint are present.
+    expect(container.querySelector('.timeline-embed-card')).toBeInTheDocument();
+    expect(screen.getByText(/saved in this browser automatically/i)).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/tolerancecalculator.test.tsx
+++ b/frontend/__tests__/tolerancecalculator.test.tsx
@@ -42,11 +42,9 @@ describe('ToleranceCalculator', () => {
     expect(selects.length).toBeGreaterThan(0);
     fireEvent.change(selects[0], { target: { value: 'TestSub' } });
 
-    // set dosage input (number inputs are role spinbutton)
-    const inputs = screen.getAllByRole('spinbutton');
-    if (inputs.length > 0) {
-      fireEvent.change(inputs[0], { target: { value: '10' } });
-    }
+    // set the dosage input (targeted via its placeholder)
+    const dosageInputs = screen.getAllByPlaceholderText('mg');
+    fireEvent.change(dosageInputs[0], { target: { value: '10' } });
 
     // Run calculation
     const calcBtn = screen.getByRole('button', { name: /Calculate Blood Levels/i });

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -461,19 +461,21 @@ html, body, #__next {
   width: 100%;
 }
 
+/* Single full-editor embed: fills the viewport height and can be resized
+   vertically by dragging its lower edge (native CSS resize handle). */
+.timeline-embed-card {
+  height: clamp(560px, 78vh, 1400px);
+  min-height: 420px;
+  resize: vertical;
+  overflow: hidden;
+}
+
 .timeline-embed-frame {
   display: block;
   width: 100%;
+  height: 100%;
   border: 0;
   background: transparent;
-}
-
-.timeline-figure-card .resizable-card__body[data-has-explicit-height="true"] {
-  overflow: hidden;
-}
-
-.timeline-settings-card .resizable-card__body[data-has-explicit-height="true"] {
-  overflow: hidden;
 }
 
 /* Enhanced Buttons with modern design */
@@ -831,6 +833,12 @@ input::placeholder,
 textarea::placeholder {
   color: var(--muted);
   opacity: 0.8;
+}
+
+/* Hide the native clear (✕) on search inputs — the app renders its own */
+.form-input[type='search']::-webkit-search-cancel-button,
+.form-input[type='search']::-webkit-search-decoration {
+  appearance: none;
 }
 
 /* Modern checkbox styles */
@@ -1455,26 +1463,10 @@ input[type="number"] {
     padding: 0.75rem;
   }
 
-  .timeline-builder-shell .resizable-card h2 {
-    font-size: 1.125rem;
-    line-height: 1.35;
+  .timeline-embed-card {
+    height: clamp(560px, 82vh, 1100px);
   }
 
-  .timeline-figure-card .resizable-card__body[data-has-explicit-height="true"],
-  .timeline-settings-card .resizable-card__body[data-has-explicit-height="true"] {
-    overflow: visible;
-  }
-
-  .timeline-embed-frame--figure {
-    height: clamp(680px, 174vw, 860px);
-    min-height: clamp(680px, 174vw, 860px);
-  }
-
-  .timeline-embed-frame--settings {
-    height: clamp(1200px, 240vh, 2000px);
-    min-height: clamp(1200px, 240vh, 2000px);
-  }
-  
   .tool-card {
     padding: 1.25rem;
     border-radius: 0.75rem;

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-/* global HTMLDivElement, getComputedStyle, Element, ResizeObserver */
+/* global HTMLDivElement, HTMLDetailsElement, getComputedStyle, Element, ResizeObserver, KeyboardEvent, MouseEvent, Node */
 import Link from 'next/link';
 import React, { useEffect, useRef } from 'react';
 import UserControls from '@/components/layout/UserControls';
+import { useAuth } from '@/components/auth/AuthContext';
 
 export default function Header() {
   const siteRef = useRef<HTMLDivElement | null>(null);
@@ -11,6 +12,29 @@ export default function Header() {
   const brandRef = useRef<HTMLDivElement | null>(null);
   const navRef = useRef<HTMLElement | null>(null);
   const rightRef = useRef<HTMLDivElement | null>(null);
+  const dropdownRef = useRef<HTMLDetailsElement | null>(null);
+  const { isAuthenticated } = useAuth();
+
+  const closeDropdown = () => dropdownRef.current?.removeAttribute('open');
+
+  // Close the mobile dropdown on outside click or Escape — <details> keeps
+  // itself open otherwise, even after navigating.
+  useEffect(() => {
+    const onPointerDown = (e: MouseEvent) => {
+      if (dropdownRef.current?.open && !dropdownRef.current.contains(e.target as Node)) {
+        closeDropdown();
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeDropdown();
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
 
   useEffect(() => {
     function compute() {
@@ -140,6 +164,14 @@ export default function Header() {
               <span className="nav-emoji group-hover:animate-bounce-subtle transition-transform duration-300">🧭</span>
               <span className="nav-label truncate">Timeline</span>
             </Link>
+            <Link
+              href="/tools/training"
+              className={`nav-item inline-flex items-center justify-center flex-1 h-full px-4 btn-nav text-sm no-underline group`}
+              aria-label="Training Tracker"
+            >
+              <span className="nav-emoji group-hover:animate-bounce-subtle transition-transform duration-300">💪</span>
+              <span className="nav-label truncate">Training</span>
+            </Link>
           </nav>
         </div>
 
@@ -149,11 +181,12 @@ export default function Header() {
 
           {/* Enhanced mobile overflow: dropdown */}
           <div className="mobile-dropdown mobile-only" style={{position:'relative'}}>
-            <details open={false}>
+            <details ref={dropdownRef}>
               <summary
                 className="list-none rounded-lg transition-colors duration-200 cursor-pointer"
                 style={{padding:'0.5rem 0.75rem', display:'block'}}
                 aria-haspopup="true"
+                aria-label="Open tools menu"
               >
                 <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24" style={{width:20,height:20,color:'var(--fg)'}}>
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -163,25 +196,28 @@ export default function Header() {
                 <div className="uppercase tracking-wider" style={{padding:'0.5rem 0.75rem', fontSize:'0.75rem', fontWeight:700, color:'var(--muted)'}}>
                   Tools
                 </div>
-                <Link href="/tools/dice" className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                <Link href="/tools/dice" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
                   <span className="mr-3">🎲</span>Dice Roller
                 </Link>
-                <Link href="/tools/fat-loss" className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                <Link href="/tools/fat-loss" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
                   <span className="mr-3">🏋️</span>Fat Loss Calculator
                 </Link>
-                <Link href="/tools/n26" className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                <Link href="/tools/n26" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
                   <span className="mr-3">🏦</span>N26 Transaction Analyzer
                 </Link>
-                <Link href="/tools/bloodlevel" className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                <Link href="/tools/bloodlevel" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
                   <span className="mr-3">🧪</span>Blood Level Calculator
                 </Link>
-                <Link href="/tools/timeline" className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                <Link href="/tools/timeline" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
                   <span className="mr-3">🧭</span>Timeline Builder
                 </Link>
+                <Link href="/tools/training" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                  <span className="mr-3">💪</span>Training Tracker
+                </Link>
                 <div style={{margin:'0.5rem 0', borderTop:'1px solid var(--card-border)'}}></div>
-                <Link href="/auth" className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
-                  <span className="mr-3">🔐</span>
-                  Sign In
+                <Link href="/auth" onClick={closeDropdown} className="btn-ghost block w-full text-left no-underline rounded-lg transition-colors duration-200" style={{padding:'0.625rem 0.75rem', fontSize:'0.875rem', color:'var(--fg)'}}>
+                  <span className="mr-3">{isAuthenticated ? '👤' : '🔐'}</span>
+                  {isAuthenticated ? 'Profile' : 'Sign In'}
                 </Link>
               </div>
             </details>

--- a/frontend/components/tools/BloodLevelCalculator.tsx
+++ b/frontend/components/tools/BloodLevelCalculator.tsx
@@ -44,6 +44,10 @@ const BloodLevelCalculator: React.FC = () => {
     loadSubstances();
   }, []);
 
+  // Blood level points carry the substance id; show the display name when known.
+  const substanceDisplayName = (idOrName: string) =>
+    substances.find((s) => s.id === idOrName)?.name ?? idOrName;
+
   const addIntake = () => {
     setIntakes([...intakes, {
       substance: '',
@@ -70,6 +74,18 @@ const BloodLevelCalculator: React.FC = () => {
     setLoading(true);
     setError(null);
 
+    const validIntakes = intakes.filter(
+      (intake) => intake.substance && intake.substance.trim() !== '' && intake.dosageMg > 0,
+    );
+    // Guard against a silent empty result when nothing is filled in yet —
+    // only when substances are loaded, so a failed substance fetch still
+    // lets the request through (and surfaces its own error).
+    if (validIntakes.length === 0 && substances.length > 0) {
+      setError('Calculation failed — select a substance and enter a dosage greater than 0 for at least one intake.');
+      setLoading(false);
+      return;
+    }
+
     try {
       const now = new Date();
       const timePoints = [];
@@ -79,8 +95,7 @@ const BloodLevelCalculator: React.FC = () => {
       }
 
       const request = {
-        intakes: intakes
-          .filter(intake => intake.substance && intake.substance.trim() !== '' && intake.dosageMg > 0)
+        intakes: validIntakes
           .map(intake => ({
             substance: intake.substance,
             time: intake.time,
@@ -132,7 +147,9 @@ const BloodLevelCalculator: React.FC = () => {
                       >
                         <option value="">Select substance...</option>
                         {substances.map((sub) => (
-                          <option key={sub.id} value={sub.id}>
+                          // The backend matches intakes by substance name, so the
+                          // name (not the id) is the wire value.
+                          <option key={sub.id} value={sub.name}>
                             {sub.name}
                           </option>
                         ))}
@@ -246,7 +263,7 @@ const BloodLevelCalculator: React.FC = () => {
               return (
                 <div key={substance} className="space-y-3">
                   <h3 className="text-lg font-medium" style={{ color: 'var(--fg)' }}>
-                    {substance} Blood Levels
+                    {substanceDisplayName(substance)} Blood Levels
                   </h3>
                   <LineChart
                     data={substanceData}
@@ -268,7 +285,7 @@ const BloodLevelCalculator: React.FC = () => {
                 return (
                   <div key={substance} className="rounded-xl p-4" style={{ background: 'rgba(59,130,246,0.10)', border: '1px solid rgba(59,130,246,0.3)' }}>
                     <div className="flex justify-between items-center">
-                      <span className="font-medium" style={{ color: 'var(--fg)' }}>{substance}</span>
+                      <span className="font-medium" style={{ color: 'var(--fg)' }}>{substanceDisplayName(substance)}</span>
                       <span className="text-sm font-semibold" style={{ color: '#3b82f6' }}>
                         Now: {currentLevel.toFixed(2)} mg
                       </span>

--- a/frontend/components/tools/TimelineBuilder.tsx
+++ b/frontend/components/tools/TimelineBuilder.tsx
@@ -1,100 +1,71 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
-import ResizableCardSection, { type CardSizePreset } from '@/components/ui/ResizableCardSection';
+/* global HTMLIFrameElement */
+import React, { useEffect, useRef, useState } from 'react';
 
-const timelinePresets: CardSizePreset[] = [
-  { label: 'Compact', width: 960, height: 620 },
-  { label: 'Default', width: 1280, height: 760 },
-  { label: 'Expanded', width: 1600, height: 1000 },
-];
-
-const timelineDefaultSize = { width: 1280, height: 760 };
-
-const settingsPresets: CardSizePreset[] = [
-  { label: 'Compact', width: 960, height: 900 },
-  { label: 'Default', width: 1280, height: 1860 },
-  { label: 'Expanded', width: 1600, height: 2400 },
-];
-
-const settingsDefaultSize = { width: 1280, height: 1860 };
-const initialTimelineSrc = '../timeline/timeline.html?panel=timeline&theme=light';
-const initialSettingsSrc = '../timeline/timeline.html?panel=settings&theme=light';
-
+/**
+ * Embeds the standalone timeline editor (frontend/public/timeline) once, in
+ * its full layout (figure + settings table). Theme changes are forwarded via
+ * postMessage so the iframe never reloads — a reload would discard edits not
+ * yet exported (the editor additionally persists to localStorage).
+ */
 export default function TimelineBuilder() {
-  const [timelineSrc, setTimelineSrc] = useState(process.env.NODE_ENV === 'test' ? 'about:blank' : initialTimelineSrc);
-  const [settingsSrc, setSettingsSrc] = useState(process.env.NODE_ENV === 'test' ? 'about:blank' : initialSettingsSrc);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [src, setSrc] = useState('about:blank');
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
 
+  // Track the app theme (the editor lives in an iframe and cannot see it).
   useEffect(() => {
     const syncTheme = () => {
       setTheme(document.documentElement.classList.contains('dark') ? 'dark' : 'light');
     };
-
     syncTheme();
     const observer = new window.MutationObserver(syncTheme);
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
     return () => observer.disconnect();
   }, []);
 
+  // Compute the iframe URL once — the theme is only baked in for the initial
+  // load; later changes go through postMessage (no reload).
   useEffect(() => {
-    if (process.env.NODE_ENV === 'test') {
-      return;
-    }
-
+    if (process.env.NODE_ENV === 'test') return;
     const marker = '/tools/timeline';
     const { pathname } = window.location;
     const markerIndex = pathname.indexOf(marker);
     const basePath = markerIndex >= 0 ? pathname.slice(0, markerIndex) : '';
-    const timelinePath = `${basePath}/timeline/timeline.html`;
-    setTimelineSrc(`${timelinePath}?panel=timeline&theme=${theme}`);
-    setSettingsSrc(`${timelinePath}?panel=settings&theme=${theme}`);
+    const initialTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    setSrc(`${basePath}/timeline/timeline.html?panel=full&theme=${initialTheme}`);
+  }, []);
+
+  // Forward theme changes into the running editor.
+  useEffect(() => {
+    try {
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: 'timeline-theme', theme },
+        window.location.origin,
+      );
+    } catch {
+      // Iframe not ready or cross-origin sandbox (tests) — initial URL theme applies.
+    }
   }, [theme]);
 
   return (
-    <div className="timeline-builder-shell p-3 sm:p-6 lg:p-8 space-y-4 sm:space-y-6">
-      <ResizableCardSection
-        title="Timeline"
-        gradient="from-cyan-400 to-teal-500"
-        presets={timelinePresets}
-        defaultSize={timelineDefaultSize}
-        className="timeline-figure-card mx-auto"
-        bodyClassName="timeline-embed-body timeline-embed-body--figure"
-        delay="100ms"
-      >
+    <div className="timeline-builder-shell p-3 sm:p-6 lg:p-8">
+      <div className="timeline-embed-card card animate-fade-in-up" style={{ padding: '0.75rem' }}>
         <iframe
-          title="Timeline builder preview"
-          src={timelineSrc}
-          className="timeline-embed-frame timeline-embed-frame--figure block w-full h-full"
-          style={{
-            border: 0,
-            background: 'transparent',
-          }}
+          ref={iframeRef}
+          title="Timeline editor"
+          src={src}
+          className="timeline-embed-frame block w-full"
+          style={{ border: 0, background: 'transparent' }}
           sandbox="allow-downloads allow-forms allow-same-origin allow-scripts"
         />
-      </ResizableCardSection>
-
-      <ResizableCardSection
-        title="Timeline Settings Table"
-        gradient="from-cyan-400 to-teal-500"
-        presets={settingsPresets}
-        defaultSize={settingsDefaultSize}
-        maxHeight={3200}
-        className="timeline-settings-card mx-auto"
-        bodyClassName="timeline-embed-body timeline-embed-body--settings"
-        delay="200ms"
-      >
-        <iframe
-          title="Timeline builder settings table"
-          src={settingsSrc}
-          className="timeline-embed-frame timeline-embed-frame--settings block w-full h-full"
-          style={{
-            border: 0,
-            background: 'transparent',
-          }}
-          sandbox="allow-downloads allow-forms allow-same-origin allow-scripts"
-        />
-      </ResizableCardSection>
+      </div>
+      <p className="text-xs mt-3" style={{ color: 'var(--muted)' }}>
+        Your figure is saved in this browser automatically. Use Export for a portable copy
+        (PNG, SVG, PDF, or setup JSON) and Import to load one. Drag the lower edge of the
+        editor to give it more room.
+      </p>
     </div>
   );
 }

--- a/frontend/components/ui/BackendBanner.tsx
+++ b/frontend/components/ui/BackendBanner.tsx
@@ -1,24 +1,32 @@
 "use client";
 
 import { useState, useEffect } from 'react';
+import { useBackendStatus, checkBackend } from '@/lib/api/backendStatus';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 export default function BackendBanner() {
-  const [offline, setOffline] = useState(false);
+  const status = useBackendStatus();
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
-    // Skip check if no API URL is configured (e.g. GitHub Pages demo)
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-    fetch(`${API_BASE_URL}/api/health`, { signal: controller.signal })
-      .then((r) => { clearTimeout(timer); if (!r.ok) setOffline(true); })
-      .catch(() => setOffline(true));
-    return () => { controller.abort(); clearTimeout(timer); };
+    void checkBackend();
+
+    // Re-probe when the tab regains focus or the network comes back, so the
+    // banner clears (and tools switch back to the backend) without a reload.
+    const recheck = () => void checkBackend(true);
+    window.addEventListener('online', recheck);
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') void checkBackend();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      window.removeEventListener('online', recheck);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, []);
 
-  if (!offline || dismissed) return null;
+  if (status !== 'offline' || dismissed) return null;
 
   return (
     <div style={{background:'rgba(251,191,36,0.08)', borderBottom:'1px solid rgba(245,158,11,0.3)', padding:'0.375rem 1rem'}}>
@@ -29,10 +37,12 @@ export default function BackendBanner() {
               d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
           </svg>
           <span style={{overflow:'hidden'}}>
-            <strong>Backend unavailable.</strong>
+            <strong>No backend connected.</strong>
             {' '}
             <span style={{opacity:0.85}}>
-              {API_BASE_URL === '' ? 'Static demo — no backend connected.' : 'Calculations require a running backend.'}
+              {API_BASE_URL === ''
+                ? 'Calculations run locally in your browser; accounts and history are unavailable.'
+                : 'Calculations run locally in your browser until the backend is reachable again.'}
             </span>
           </span>
         </div>

--- a/frontend/lib/api/backendStatus.ts
+++ b/frontend/lib/api/backendStatus.ts
@@ -1,0 +1,110 @@
+// Shared backend availability tracker.
+//
+// One health probe is shared by the whole app (banner, API client). Tool calls
+// stay optimistic — they hit the backend directly and only consult this module
+// after a network-level failure — so the online path adds zero latency.
+// Once the backend is known to be offline, calls skip the network entirely and
+// compute locally, while periodic re-probes detect recovery.
+import { useSyncExternalStore } from 'react';
+
+export type BackendStatus = 'unknown' | 'online' | 'offline';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+/** Health probe timeout — keep short so offline detection feels instant. */
+const PROBE_TIMEOUT_MS = 3_000;
+/** While online, trust the last probe for this long. */
+const ONLINE_RECHECK_MS = 5 * 60_000;
+/** While offline, re-probe more eagerly so recovery is picked up quickly. */
+const OFFLINE_RECHECK_MS = 15_000;
+
+let status: BackendStatus = 'unknown';
+let lastProbeAt = 0;
+let inflight: Promise<boolean> | null = null;
+const listeners = new Set<() => void>();
+
+function setStatus(next: BackendStatus): void {
+  lastProbeAt = Date.now();
+  if (status === next) return;
+  status = next;
+  listeners.forEach((listener) => listener());
+}
+
+export function getBackendStatus(): BackendStatus {
+  return status;
+}
+
+export function isBackendOffline(): boolean {
+  return status === 'offline';
+}
+
+export function subscribeBackendStatus(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Mark offline immediately (called when a real API call hits a network error). */
+export function markBackendOffline(): void {
+  setStatus('offline');
+}
+
+/** Mark online (called when any real API call succeeds). */
+export function markBackendOnline(): void {
+  setStatus('online');
+}
+
+async function probe(): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/health`, {
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Check backend availability. Results are cached (shorter TTL while offline)
+ * and concurrent calls share a single in-flight probe.
+ */
+export function checkBackend(force = false): Promise<boolean> {
+  if (inflight) return inflight;
+
+  const ttl = status === 'offline' ? OFFLINE_RECHECK_MS : ONLINE_RECHECK_MS;
+  if (!force && status !== 'unknown' && Date.now() - lastProbeAt < ttl) {
+    return Promise.resolve(status === 'online');
+  }
+
+  inflight = probe()
+    .then((ok) => {
+      setStatus(ok ? 'online' : 'offline');
+      return ok;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/** Test-only helper: reset module state between test cases. */
+export function resetBackendStatusForTests(): void {
+  status = 'unknown';
+  lastProbeAt = 0;
+  inflight = null;
+}
+
+/** React hook — re-renders when backend availability changes. */
+export function useBackendStatus(): BackendStatus {
+  return useSyncExternalStore(
+    subscribeBackendStatus,
+    getBackendStatus,
+    () => 'unknown' as BackendStatus,
+  );
+}

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,6 +1,18 @@
 // Use named exports for all API functions to keep imports consistent across the codebase.
 // Use a relative default so tests and client-side code that expect
 // relative API paths don't attempt to call an absolute localhost URL.
+import {
+  isBackendOffline,
+  markBackendOffline,
+  markBackendOnline,
+  checkBackend,
+} from '@/lib/api/backendStatus';
+import { rollDiceLocal } from '@/lib/local/dice';
+import { calculateFatLossLocal } from '@/lib/local/fatLoss';
+import { analyzeN26DataLocal } from '@/lib/local/n26';
+import { getSubstancesLocal, calculateToleranceLocal } from '@/lib/local/bloodLevel';
+import type { DiceRequest as DiceRequestFull } from '@/lib/types/dice';
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 /** Default request timeout in milliseconds (15 seconds). */
@@ -83,6 +95,42 @@ async function apiRequest<T>(
   }
 }
 
+/**
+ * True for failures that mean "backend unreachable" (DNS/connection refused/
+ * timeout), as opposed to HTTP errors the backend itself produced.
+ */
+function isNetworkError(err: unknown): boolean {
+  if (err instanceof TypeError) return true; // fetch network failure
+  return err instanceof Error && err.name === 'AbortError'; // request timeout
+}
+
+/**
+ * Run a backend call with a client-side fallback.
+ *
+ * The remote call is attempted first (zero added latency while online). Only a
+ * network-level failure switches to the local implementation — HTTP errors
+ * (validation, 4xx/5xx) are still surfaced to the caller. Once the backend is
+ * known to be offline, the network is skipped entirely for instant local
+ * results, while a shared probe periodically checks for recovery.
+ */
+async function withLocalFallback<T>(remote: () => Promise<T>, local: () => T): Promise<T> {
+  if (isBackendOffline()) {
+    void checkBackend(); // cheap: cached + deduplicated, detects recovery
+    return local();
+  }
+  try {
+    const result = await remote();
+    markBackendOnline();
+    return result;
+  } catch (err) {
+    if (isNetworkError(err)) {
+      markBackendOffline();
+      return local();
+    }
+    throw err;
+  }
+}
+
 /** Shorthand for JSON POST requests with credentials. */
 function jsonPost<T>(path: string, body: unknown, errorPrefix: string): Promise<T> {
   return apiRequest<T>(
@@ -138,14 +186,18 @@ export interface RollDicePayload {
 }
 
 export async function rollDice(payload: RollDicePayload) {
-  return apiRequest(
-    `${API_BASE_URL}/api/tools/dice/roll`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    },
-    'Roll API error',
+  return withLocalFallback(
+    () =>
+      apiRequest(
+        `${API_BASE_URL}/api/tools/dice/roll`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+        'Roll API error',
+      ),
+    () => rollDiceLocal(payload as DiceRequestFull),
   );
 }
 
@@ -165,14 +217,18 @@ export interface FatLossResponse {
 export async function calculateFatLoss(
   request: FatLossRequest,
 ): Promise<FatLossResponse> {
-  return apiRequest<FatLossResponse>(
-    `${API_BASE_URL}/api/tools/fat-loss`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(request),
-    },
-    'Failed to calculate fat loss',
+  return withLocalFallback(
+    () =>
+      apiRequest<FatLossResponse>(
+        `${API_BASE_URL}/api/tools/fat-loss`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(request),
+        },
+        'Failed to calculate fat loss',
+      ),
+    () => calculateFatLossLocal(request),
   );
 }
 
@@ -192,14 +248,18 @@ export interface AnalysisResult {
 }
 
 export async function analyzeN26Data(data: Record<string, unknown>): Promise<AnalysisResult> {
-  return apiRequest<AnalysisResult>(
-    `${API_BASE_URL}/api/tools/n26-analyzer`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    },
-    'Failed to analyze N26 data',
+  return withLocalFallback(
+    () =>
+      apiRequest<AnalysisResult>(
+        `${API_BASE_URL}/api/tools/n26-analyzer`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        },
+        'Failed to analyze N26 data',
+      ),
+    () => analyzeN26DataLocal(data),
   );
 }
 
@@ -324,24 +384,32 @@ export interface ToleranceCalculationResponse {
 }
 
 export async function getToleranceSubstances(): Promise<Substance[]> {
-  return apiRequest<Substance[]>(
-    `${API_BASE_URL}/api/tools/bloodlevel/substances`,
-    { method: 'GET', headers: { 'Content-Type': 'application/json' } },
-    'Failed to get substances',
+  return withLocalFallback(
+    () =>
+      apiRequest<Substance[]>(
+        `${API_BASE_URL}/api/tools/bloodlevel/substances`,
+        { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+        'Failed to get substances',
+      ),
+    () => getSubstancesLocal(),
   );
 }
 
 export async function calculateTolerance(
   request: ToleranceCalculationRequest,
 ): Promise<ToleranceCalculationResponse> {
-  return apiRequest<ToleranceCalculationResponse>(
-    `${API_BASE_URL}/api/tools/bloodlevel/calculate`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(request),
-    },
-    'Failed to calculate tolerance',
+  return withLocalFallback(
+    () =>
+      apiRequest<ToleranceCalculationResponse>(
+        `${API_BASE_URL}/api/tools/bloodlevel/calculate`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(request),
+        },
+        'Failed to calculate tolerance',
+      ),
+    () => calculateToleranceLocal(request),
   );
 }
 

--- a/frontend/lib/local/bloodLevel.ts
+++ b/frontend/lib/local/bloodLevel.ts
@@ -1,0 +1,137 @@
+// Client-side blood level calculation — mirrors backend/src/tools/bloodlevel.rs
+// (same substance database, bioavailability and half-life decay model).
+import type {
+  Substance,
+  ToleranceCalculationRequest,
+  ToleranceCalculationResponse,
+  BloodLevelPoint,
+} from '@/lib/api/client';
+
+interface LocalSubstance {
+  id: string;
+  name: string;
+  halfLifeHours: number;
+  description: string;
+  category: string;
+  commonDosageMg: number;
+  maxDailyDoseMg: number;
+  eliminationRoute: string;
+  bioavailabilityPercent: number;
+}
+
+// Keep in sync with get_substances() in backend/src/tools/bloodlevel.rs.
+const SUBSTANCES: LocalSubstance[] = [
+  {
+    id: 'caffeine',
+    name: 'Caffeine',
+    halfLifeHours: 5.7,
+    description: 'Central nervous system stimulant',
+    category: 'Stimulant',
+    commonDosageMg: 100,
+    maxDailyDoseMg: 400,
+    eliminationRoute: 'Hepatic metabolism',
+    bioavailabilityPercent: 99,
+  },
+  {
+    id: 'nicotine',
+    name: 'Nicotine',
+    halfLifeHours: 2,
+    description: 'Addictive stimulant found in tobacco',
+    category: 'Stimulant',
+    commonDosageMg: 1,
+    maxDailyDoseMg: 4,
+    eliminationRoute: 'Hepatic metabolism',
+    bioavailabilityPercent: 90,
+  },
+  {
+    id: 'alcohol',
+    name: 'Alcohol (Ethanol)',
+    halfLifeHours: 4,
+    description: 'Depressant affecting CNS',
+    category: 'Depressant',
+    commonDosageMg: 14000,
+    maxDailyDoseMg: 56000,
+    eliminationRoute: 'Hepatic metabolism',
+    bioavailabilityPercent: 100,
+  },
+  {
+    id: 'ibuprofen',
+    name: 'Ibuprofen',
+    halfLifeHours: 2,
+    description: 'Non-steroidal anti-inflammatory drug',
+    category: 'NSAID',
+    commonDosageMg: 200,
+    maxDailyDoseMg: 1200,
+    eliminationRoute: 'Hepatic metabolism',
+    bioavailabilityPercent: 80,
+  },
+  {
+    id: 'paracetamol',
+    name: 'Acetaminophen (Paracetamol)',
+    halfLifeHours: 2,
+    description: 'Pain reliever and fever reducer',
+    category: 'Analgesic',
+    commonDosageMg: 500,
+    maxDailyDoseMg: 4000,
+    eliminationRoute: 'Hepatic metabolism',
+    bioavailabilityPercent: 79,
+  },
+];
+
+export function getSubstancesLocal(): Substance[] {
+  return SUBSTANCES.map((s) => ({ ...s }));
+}
+
+function findSubstance(idOrName: string): LocalSubstance | undefined {
+  const needle = idOrName.toLowerCase();
+  return SUBSTANCES.find(
+    (s) => s.id.toLowerCase() === needle || s.name.toLowerCase() === needle,
+  );
+}
+
+export function calculateToleranceLocal(
+  request: ToleranceCalculationRequest,
+): ToleranceCalculationResponse {
+  const bloodLevels: BloodLevelPoint[] = [];
+
+  // Group intakes by substance, like the backend does.
+  const bySubstance = new Map<string, typeof request.intakes>();
+  for (const intake of request.intakes) {
+    const group = bySubstance.get(intake.substance) ?? [];
+    group.push(intake);
+    bySubstance.set(intake.substance, group);
+  }
+
+  for (const [substanceName, intakes] of bySubstance) {
+    const substance = findSubstance(substanceName);
+    if (!substance) {
+      throw new Error(`Substance '${substanceName}' not found in database`);
+    }
+
+    for (const timePoint of request.time_points) {
+      let totalAmount = 0;
+      const pointMs = Date.parse(timePoint);
+
+      for (const intake of intakes) {
+        const elapsedMs = pointMs - Date.parse(intake.time);
+        if (!Number.isFinite(elapsedMs) || elapsedMs < 0) continue;
+
+        const hoursElapsed = elapsedMs / 3_600_000;
+        const bioavailableDose = intake.dosage_mg * (substance.bioavailabilityPercent / 100);
+        const remaining =
+          substance.halfLifeHours > 0
+            ? bioavailableDose * Math.pow(0.5, hoursElapsed / substance.halfLifeHours)
+            : 0;
+        totalAmount += Number.isFinite(remaining) ? remaining : 0;
+      }
+
+      bloodLevels.push({
+        time: timePoint,
+        substance: substanceName,
+        amount_mg: Number.isFinite(totalAmount) ? totalAmount : 0,
+      });
+    }
+  }
+
+  return { blood_levels: bloodLevels };
+}

--- a/frontend/lib/local/dice.ts
+++ b/frontend/lib/local/dice.ts
@@ -1,0 +1,154 @@
+// Client-side dice rolling — mirrors backend/src/tools/dice.rs (validation,
+// limits, advantage modes, rerolls, stats) so offline rolls behave the same.
+// Uses the Web Crypto CSPRNG with rejection sampling for unbiased results.
+import type { DiceRequest, DiceResponse, DiceRollResult, PerDieDetail } from '@/lib/types/dice';
+
+const MAX_DICE = 1000;
+const MAX_SIDES = 10000;
+const MAX_REROLLS_PER_DIE = 1000;
+const MAX_INDEPENDENT_ROLLS = 100;
+
+const DIE_SIDES: Record<string, number> = {
+  d2: 2,
+  d3: 3,
+  d4: 4,
+  d6: 6,
+  d8: 8,
+  d10: 10,
+  d12: 12,
+  d20: 20,
+};
+
+/** Unbiased random integer in [1, sides] via CSPRNG rejection sampling. */
+function randomDieValue(sides: number): number {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj?.getRandomValues) {
+    // Largest multiple of `sides` below 2^32 — reject values above it.
+    const limit = Math.floor(0x1_0000_0000 / sides) * sides;
+    const buf = new Uint32Array(1);
+    let x: number;
+    do {
+      cryptoObj.getRandomValues(buf);
+      x = buf[0];
+    } while (x >= limit);
+    return 1 + (x % sides);
+  }
+  // Environments without Web Crypto (old test runners) — non-cryptographic fallback.
+  return 1 + Math.floor(Math.random() * sides);
+}
+
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid] + sorted[mid - 1]) / 2;
+}
+
+function buildStats(perDie: PerDieDetail[], used: number[]): DiceRollResult {
+  const sum = used.reduce((a, b) => a + b, 0);
+  const average = used.length === 0 ? 0 : sum / used.length;
+  const sorted = [...used].sort((a, b) => a - b);
+  const spread = sorted.length === 0 ? 0 : sorted[sorted.length - 1] - sorted[0];
+  return { perDie, used, sum, average, median: median(sorted), spread };
+}
+
+export function rollDiceLocal(request: DiceRequest): DiceResponse {
+  if (!request.count || request.count <= 0) {
+    throw new Error('count must be > 0');
+  }
+  if (request.count >= MAX_DICE) {
+    throw new Error('count exceeds max allowed');
+  }
+
+  let sides: number;
+  if (request.die.type === 'custom') {
+    sides = request.die.sides ?? 6;
+  } else if (DIE_SIDES[request.die.type]) {
+    sides = DIE_SIDES[request.die.type];
+  } else {
+    throw new Error('unknown die type');
+  }
+  if (sides > MAX_SIDES) {
+    throw new Error('sides exceeds max allowed');
+  }
+
+  const rolls = request.rolls ?? 1;
+  if (rolls > MAX_INDEPENDENT_ROLLS) {
+    throw new Error('too many independent rolls requested');
+  }
+
+  const maxRerolls = Math.min(request.maxRerollsPerDie ?? 10, MAX_REROLLS_PER_DIE);
+
+  const estWork = request.count * (maxRerolls + 1) * rolls;
+  const safeThreshold = MAX_DICE * (MAX_REROLLS_PER_DIE + 1) * MAX_INDEPENDENT_ROLLS;
+  if (estWork >= safeThreshold) {
+    throw new Error('request too large; exceeds server cost limits');
+  }
+
+  const rollWithRerolls = (): { originals: number[]; final: number } => {
+    const originals: number[] = [];
+    let value = randomDieValue(sides);
+    originals.push(value);
+    if (request.reroll) {
+      const { mode, threshold } = request.reroll;
+      const effectiveMax = request.reroll.maxRerolls ?? maxRerolls;
+      let tries = 0;
+      for (;;) {
+        const should = mode === 'lt' ? value <= threshold : mode === 'gt' ? value >= threshold : false;
+        if (!should || tries >= effectiveMax) break;
+        value = randomDieValue(sides);
+        originals.push(value);
+        tries += 1;
+      }
+    }
+    return { originals, final: value };
+  };
+
+  const performSet = (): { perDie: PerDieDetail[]; used: number[] } => {
+    const perDie: PerDieDetail[] = [];
+    const used: number[] = [];
+    for (let i = 0; i < request.count; i++) {
+      const { originals, final } = rollWithRerolls();
+      perDie.push({ original: originals, final });
+      used.push(final);
+    }
+    return { perDie, used };
+  };
+
+  const advantage = request.advantage ?? 'none';
+  const advMode = request.advantageMode ?? 'per-die';
+  const results: DiceRollResult[] = [];
+
+  for (let r = 0; r < rolls; r++) {
+    if (advantage === 'none' || advMode === 'per-die') {
+      const perDie: PerDieDetail[] = [];
+      const used: number[] = [];
+      for (let i = 0; i < request.count; i++) {
+        if (advantage === 'none') {
+          const { originals, final } = rollWithRerolls();
+          perDie.push({ original: originals, final });
+          used.push(final);
+        } else {
+          const first = rollWithRerolls();
+          const second = rollWithRerolls();
+          const chosen =
+            advantage === 'adv'
+              ? Math.max(first.final, second.final)
+              : Math.min(first.final, second.final);
+          perDie.push({ original: [...first.originals, ...second.originals], final: chosen });
+          used.push(chosen);
+        }
+      }
+      results.push(buildStats(perDie, used));
+    } else {
+      const set1 = performSet();
+      const set2 = performSet();
+      const sum1 = set1.used.reduce((a, b) => a + b, 0);
+      const sum2 = set2.used.reduce((a, b) => a + b, 0);
+      const pickFirst = advantage === 'adv' ? sum1 >= sum2 : sum1 <= sum2;
+      const picked = pickFirst ? set1 : set2;
+      results.push(buildStats(picked.perDie, picked.used));
+    }
+  }
+
+  return { rolls: results, summary: { totalRollsRequested: rolls } };
+}

--- a/frontend/lib/local/fatLoss.ts
+++ b/frontend/lib/local/fatLoss.ts
@@ -1,0 +1,29 @@
+// Client-side fat loss calculation — mirrors backend/src/tools/fat_loss.rs
+// so results are identical with or without a backend.
+import type { FatLossRequest, FatLossResponse } from '@/lib/api/client';
+
+const KCAL_PER_KG_FAT = 7000;
+const KCAL_PER_KG_MUSCLE = 1200;
+
+export function calculateFatLossLocal(request: FatLossRequest): FatLossResponse {
+  const { kcal_deficit, weight_loss_kg } = request;
+
+  if (!(kcal_deficit > 0) || !(weight_loss_kg > 0)) {
+    return { fat_loss_percentage: null, muscle_loss_percentage: null, is_valid: false };
+  }
+
+  const fatFraction =
+    (kcal_deficit - KCAL_PER_KG_MUSCLE * weight_loss_kg) /
+    (KCAL_PER_KG_FAT - KCAL_PER_KG_MUSCLE) /
+    weight_loss_kg;
+
+  if (!(fatFraction >= 0 && fatFraction <= 1)) {
+    return { fat_loss_percentage: null, muscle_loss_percentage: null, is_valid: false };
+  }
+
+  return {
+    fat_loss_percentage: fatFraction * 100,
+    muscle_loss_percentage: (1 - fatFraction) * 100,
+    is_valid: true,
+  };
+}

--- a/frontend/lib/local/n26.ts
+++ b/frontend/lib/local/n26.ts
@@ -1,0 +1,86 @@
+// Client-side N26 export analysis — mirrors backend/src/tools/n26_analyzer.rs.
+// All processing stays in the browser; nothing is uploaded when offline.
+import type { AnalysisResult, Transaction } from '@/lib/api/client';
+
+type JsonRecord = Record<string, unknown>;
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function processCategory(
+  entries: unknown[],
+  category: string,
+  amountField: string,
+  dateField: string,
+  commentField: string,
+): Transaction[] {
+  const transactions: Transaction[] = [];
+  for (const raw of entries) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const entry = raw as JsonRecord;
+    const amount = asNumber(entry[amountField]);
+    const date = asString(entry[dateField]);
+    const comment = asString(entry[commentField]);
+    if (amount !== undefined && date !== undefined && comment !== undefined) {
+      transactions.push({ amount, date, category, comment });
+    }
+  }
+  return transactions;
+}
+
+export function analyzeN26DataLocal(data: Record<string, unknown>): AnalysisResult {
+  const inner = data?.data;
+  if (typeof inner !== 'object' || inner === null) {
+    throw new Error('Invalid N26 data: missing "data" object');
+  }
+  const sections = inner as JsonRecord;
+  const transactions: Transaction[] = [];
+
+  const cashData = sections.cash26Data;
+  if (Array.isArray(cashData)) {
+    transactions.push(
+      ...processCategory(cashData, 'cash26Data', 'amount', 'transaction_date', 'transaction_type'),
+    );
+  }
+
+  const bankData = sections.bankTransfers;
+  if (Array.isArray(bankData)) {
+    transactions.push(
+      ...processCategory(bankData, 'bankTransfers', 'amount', 'ts', 'reference_text'),
+    );
+  }
+
+  const cardData = sections.cardTransactions;
+  if (Array.isArray(cardData)) {
+    for (const raw of cardData) {
+      if (typeof raw !== 'object' || raw === null) continue;
+      const entry = raw as JsonRecord;
+      const endAmount = asNumber(entry.end_amount);
+      const date = asString(entry.transaction_date);
+      const merchant = asString(entry.merchant_name);
+      if (endAmount !== undefined && date !== undefined && merchant !== undefined) {
+        const originalAmount = asNumber(entry.original_amount) ?? endAmount;
+        transactions.push({
+          amount: -endAmount,
+          date,
+          category: 'cardTransactions',
+          comment: `${merchant}: ${originalAmount}`,
+        });
+      }
+    }
+  }
+
+  const categoryTotals: Record<string, number> = {};
+  let overallTotal = 0;
+  for (const tx of transactions) {
+    categoryTotals[tx.category] = (categoryTotals[tx.category] ?? 0) + tx.amount;
+    overallTotal += tx.amount;
+  }
+
+  return { transactions, category_totals: categoryTotals, overall_total: overallTotal };
+}

--- a/frontend/public/timeline/src/editor/timeline-persistence.js
+++ b/frontend/public/timeline/src/editor/timeline-persistence.js
@@ -1,0 +1,50 @@
+/**
+ * Persists the timeline figure to localStorage so edits survive reloads,
+ * navigation, and theme changes.
+ *
+ * Load order matters: this script must run after timeline-config.js (it
+ * chains onto window.timelineConfigReady so a saved figure wins over the
+ * bundled default) and before timeline-generator.js renders.
+ */
+(function () {
+  var STORAGE_KEY = "tools-timeline-config-v1";
+
+  function readSaved() {
+    try {
+      var raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      var parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  // Restore: prefer the saved figure over the bundled default config.
+  if (window.timelineConfigReady && typeof window.timelineConfigReady.then === "function") {
+    window.timelineConfigReady = window.timelineConfigReady.then(function (config) {
+      var saved = readSaved();
+      if (saved) {
+        window.TIMELINE_CONFIG = saved;
+        return saved;
+      }
+      return config;
+    });
+  }
+
+  // Save (debounced) after every render — covers edits, imports, undo/redo,
+  // and "New figure" alike.
+  var saveTimer = null;
+  document.addEventListener("timeline:rendered", function (event) {
+    var config = (event.detail && event.detail.config) || window.TIMELINE_CONFIG;
+    if (!config) return;
+    if (saveTimer) window.clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(function () {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+      } catch (_error) {
+        // Storage full or blocked — editing continues without persistence.
+      }
+    }, 250);
+  });
+})();

--- a/frontend/public/timeline/style/timeline.css
+++ b/frontend/public/timeline/style/timeline.css
@@ -1277,6 +1277,16 @@ html[data-embed-panel] .timeline-wrap {
   padding: 0;
 }
 
+/* Full embed: figure + settings table in a single frame, no page chrome */
+html[data-embed-panel="full"] .shell {
+  max-width: none;
+  margin: 0;
+}
+
+html[data-embed-panel="full"] .timeline-wrap {
+  padding: 4px 4px 12px;
+}
+
 html[data-embed-panel="timeline"] .timeline-frame {
   border: 0;
   border-radius: 0;

--- a/frontend/public/timeline/timeline.html
+++ b/frontend/public/timeline/timeline.html
@@ -7,7 +7,7 @@
   <script>
     (function () {
       const panel = new URLSearchParams(window.location.search).get('panel');
-      if (panel === 'timeline' || panel === 'settings') {
+      if (panel === 'timeline' || panel === 'settings' || panel === 'full') {
         document.documentElement.dataset.embedPanel = panel;
       }
     })();
@@ -190,6 +190,7 @@
   <script src="./src/config/timeline-default-config.js"></script>
   <script src="./src/config/timeline-presets.js"></script>
   <script src="./src/config/timeline-config.js"></script>
+  <script src="./src/editor/timeline-persistence.js"></script>
   <script src="./src/render/timeline-generator.js"></script>
   <script src="./src/export/timeline-exporter.js"></script>
   <script src="./src/editor/timeline-editor.js"></script>
@@ -241,6 +242,15 @@
           update();
         });
       }
+      // Embedding pages switch the theme via postMessage so the editor does
+      // not have to reload (a reload would discard unsaved edits).
+      window.addEventListener('message', (event) => {
+        const data = event.data;
+        if (!data || data.type !== 'timeline-theme') return;
+        if (data.theme !== 'dark' && data.theme !== 'light') return;
+        theme = data.theme;
+        update();
+      });
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- **Backend auto-detection + client-side fallback**: shared `/api/health` status store; dice / fat-loss / blood-level / N26 compute locally in the browser (logic mirrors the Rust implementations) when the backend is unreachable, and switch back automatically on recovery. Online path unchanged (zero added latency); HTTP errors never fall back.
- **Blood level fixes**: the substance dropdown sent ids while the backend matched display names, so Alcohol and Paracetamol always failed — options now send names and the backend matcher accepts id or name; empty submissions get a validation message; charts show display names.
- **UI fixes**: Training Tracker added to desktop nav + mobile dropdown; dropdown closes on link click / outside click / Escape and is auth-aware; duplicate native clear button on the home search removed.
- **Timeline rework**: single `panel=full` iframe instead of two fixed-size BroadcastChannel-synced embeds; theme switches via postMessage without reloading (a reload silently discarded all edits); figure autosaves to localStorage; viewport-based sizing with a native vertical resize handle.

## Verification
- 181 tests across 72 files pass (`pnpm --filter frontend test --run`), ESLint + production build clean
- Verified live against the static export with no backend: offline banner, correct local fat-loss results, timeline theme switch without reload, localStorage persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)