### PR TITLE
Legitimately Fix Frontend React Act Warnings

### DIFF
--- a/frontend/__tests__/bloodlevel_calculator.test.tsx
+++ b/frontend/__tests__/bloodlevel_calculator.test.tsx
@@ -2,6 +2,7 @@
 // Combines the key coverage from the previous tolerancecalculator_* tests
 import React from 'react';
 import { render, fireEvent, waitFor, within } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 // Mock the api client functions used by BloodLevelCalculator
@@ -29,24 +30,28 @@ describe('BloodLevelCalculator (consolidated)', () => {
     ] as any);
     const calc = vi.spyOn(api, 'calculateTolerance').mockResolvedValue({ blood_levels: [{ time: new Date().toISOString(), substance: 'TestSub', amountMg: 2 }] } as any);
 
-  const { container } = render(<TestWrapper><BloodLevelCalculator /></TestWrapper>);
+  let container: HTMLElement;
+  await act(async () => {
+    const res = render(<TestWrapper><BloodLevelCalculator /></TestWrapper>);
+    container = res.container;
+  });
 
   // wait for substance options to load
   await waitFor(() => expect(getSub).toHaveBeenCalled());
 
   // Add intake, choose substance, set dosage (scoped to this render)
   const addBtn = within(container).getByRole('button', { name: /Add Intake|\+ Add Intake/i });
-  fireEvent.click(addBtn);
+  await act(async () => { fireEvent.click(addBtn); });
 
   const selects = within(container).getAllByRole('combobox');
   expect(selects.length).toBeGreaterThan(0);
-  fireEvent.change(selects[0], { target: { value: 'TestSub' } });
+  await act(async () => { fireEvent.change(selects[0], { target: { value: 'TestSub' } }); });
 
   const dosageInputs = within(container).getAllByPlaceholderText('mg');
-  fireEvent.change(dosageInputs[0], { target: { value: '10' } });
+  await act(async () => { fireEvent.change(dosageInputs[0], { target: { value: '10' } }); });
 
   const calcBtn = within(container).getByRole('button', { name: /Calculate Blood Levels|calculate blood levels/i });
-  fireEvent.click(calcBtn);
+  await act(async () => { fireEvent.click(calcBtn); });
 
   await waitFor(() => expect(calc).toHaveBeenCalled());
   await waitFor(() => expect(container.querySelector('svg')).toBeTruthy());
@@ -63,14 +68,14 @@ describe('BloodLevelCalculator (consolidated)', () => {
 
     // interact with selects and inputs (scoped)
     const select = within(c1).getByDisplayValue(/Select substance.../i) as any;
-    fireEvent.change(select, { target: { value: 'Sub' } });
+    await act(async () => { fireEvent.change(select, { target: { value: 'Sub' } }); });
 
     const dosages = await within(c1).findAllByPlaceholderText('mg');
     const dosage = dosages[0] as HTMLInputElement;
-    fireEvent.change(dosage, { target: { value: '10' } });
+    await act(async () => { fireEvent.change(dosage, { target: { value: '10' } }); });
 
     const btn = within(c1).getByRole('button', { name: /calculate blood levels/i });
-    fireEvent.click(btn);
+    await act(async () => { fireEvent.click(btn); });
 
     await waitFor(() => expect(within(c1).getByText(/Sub Blood Levels/)).toBeInTheDocument());
 
@@ -81,10 +86,10 @@ describe('BloodLevelCalculator (consolidated)', () => {
     const { container: c2 } = render(<TestWrapper><BloodLevelCalculator /></TestWrapper>);
     const dosages2 = await within(c2).findAllByPlaceholderText('mg');
     const dosage2 = dosages2[0] as HTMLInputElement;
-    fireEvent.change(dosage2, { target: { value: '1' } });
+    await act(async () => { fireEvent.change(dosage2, { target: { value: '1' } }); });
 
     const btn2 = within(c2).getByRole('button', { name: /calculate blood levels/i });
-    fireEvent.click(btn2);
+    await act(async () => { fireEvent.click(btn2); });
 
     await waitFor(() => expect(within(c2).queryByText(/Calculation failed|Tolerance calc error|boom/i)).toBeTruthy());
   });
@@ -99,21 +104,22 @@ describe('BloodLevelCalculator (consolidated)', () => {
   const table = within(container).getByRole('table');
   const beforeRows = within(table).getAllByRole('row').length;
 
-  fireEvent.click(addBtn);
+  await act(async () => { fireEvent.click(addBtn); });
   const afterAddRows = within(table).getAllByRole('row').length;
   expect(afterAddRows).toBeGreaterThan(beforeRows);
 
   const removeBtns = within(container).getAllByText('Remove');
   expect(removeBtns.length).toBeGreaterThan(0);
-  fireEvent.click(removeBtns[removeBtns.length - 1]);
+  await act(async () => { fireEvent.click(removeBtns[removeBtns.length - 1]); });
 
   const afterRemoveRows = within(table).getAllByRole('row').length;
   expect(afterRemoveRows).toBe(beforeRows);
 
   const datetime = within(table).getAllByDisplayValue(() => true).find((el) => el.getAttribute('type') === 'datetime-local');
-  if (datetime) fireEvent.change(datetime, { target: { value: '2025-01-01T12:00' } });
+  if (datetime) await act(async () => { fireEvent.change(datetime, { target: { value: '2025-01-01T12:00' } }); });
 
   const intakeTypeSelect = within(table).getAllByRole('combobox').find((s) => s.tagName === 'SELECT');
-  if (intakeTypeSelect) fireEvent.change(intakeTypeSelect, { target: { value: 'inhaled' } });
+  if (intakeTypeSelect) await act(async () => { fireEvent.change(intakeTypeSelect, { target: { value: 'inhaled' } }); });
+  await act(async () => { await new Promise(r => setTimeout(r, 0)); });
   });
 });

--- a/frontend/__tests__/bloodlevel_page.test.tsx
+++ b/frontend/__tests__/bloodlevel_page.test.tsx
@@ -1,14 +1,27 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@/lib/api/client', () => ({
+  getToleranceSubstances: vi.fn().mockResolvedValue([{ id: '1', name: 'FAKE_SUBSTANCE', halfLifeHours: 4 }]),
+  calculateTolerance: vi.fn().mockResolvedValue({ blood_levels: [] })
+}));
 
 import BloodLevelPage from '@/app/tools/bloodlevel/page';
 import { TestWrapper } from '@/lib/test-utils';
 
 describe('BloodLevel page', () => {
-  it('renders the BloodLevel page component', () => {
-    render(<TestWrapper><BloodLevelPage /></TestWrapper>);
+  it('renders the BloodLevel page component', async () => {
+    await act(async () => {
+      render(<TestWrapper><BloodLevelPage /></TestWrapper>);
+      await new Promise(r => setTimeout(r, 50));
+    });
     // BloodLevelCalculator renders a button labeled 'Add Intake' in tests; assert presence
     expect(screen.queryByRole('button', { name: /Add Intake/i })).toBeTruthy();
+    // Wait for the async API call in BloodLevelCalculator to resolve
+    const api = await import('@/lib/api/client');
+    await waitFor(() => expect(api.getToleranceSubstances).toHaveBeenCalled());
+    // Wait for the state update to apply to the DOM
+    expect(await screen.findByText(/FAKE_SUBSTANCE/)).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/diceroller_add_buttons.test.tsx
+++ b/frontend/__tests__/diceroller_add_buttons.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
+vi.mock('next/link', () => ({ default: ({ children }: any) => <a>{children}</a> }));
 
 // Mock rollDice API (not needed for this test but keep shape)
 const mockRollDice = vi.fn();

--- a/frontend/__tests__/diceroller_add_buttons.test.tsx
+++ b/frontend/__tests__/diceroller_add_buttons.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { act } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
 vi.mock('next/link', () => ({ default: ({ children }: any) => <a>{children}</a> }));
 

--- a/frontend/__tests__/diceroller_lastresult_branches.test.tsx
+++ b/frontend/__tests__/diceroller_lastresult_branches.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, test, expect, vi } from 'vitest';
 
 // Mock rollDice API to return multiple rolls
@@ -22,7 +22,11 @@ const mockRollDice = vi.fn().mockResolvedValue({
   ],
   history: [8,7]
 });
-vi.mock('@/lib/api/client', () => ({ rollDice: (...args: any[]) => mockRollDice(...args) }));
+vi.mock('@/lib/api/client', () => ({
+  rollDice: (...args: any[]) => mockRollDice(...args),
+  getDiceHistory: vi.fn().mockResolvedValue([]),
+  saveDiceRoll: vi.fn().mockResolvedValue({})
+}));
 
 // Mock charts
 vi.mock('@/components/charts/Boxplot', () => ({ default: () => <div data-testid="boxplot" /> }));
@@ -32,15 +36,18 @@ import DiceRoller from '@/components/tools/DiceRoller';
 
 describe('DiceRoller lastResult mapping branches', () => {
   test('renders multiple roll entries and per-die rows', async () => {
-    render(<DiceRoller />);
+    await act(async () => {
+      render(<DiceRoller />);
+      await new Promise(r => setTimeout(r, 50));
+    });
 
     // enable charts before rolling
     const showChartsCheckbox = screen.getByLabelText('Show Charts');
-    fireEvent.click(showChartsCheckbox);
+    await act(async () => { fireEvent.click(showChartsCheckbox); await new Promise(r => setTimeout(r, 10)); });
 
     // click Roll button to cause mockRollDice to populate lastResult
     const rollButton = screen.getByText('Roll Dice');
-    rollButton.click();
+    await act(async () => { rollButton.click(); await new Promise(r => setTimeout(r, 50)); });
 
   // expect Dice Results heading and per-die reroll sequence text
   expect(await screen.findByText(/Dice Results/)).toBeInTheDocument();
@@ -51,5 +58,8 @@ describe('DiceRoller lastResult mapping branches', () => {
   expect(hists.length).toBeGreaterThanOrEqual(2);
   // check reroll sequence appears (original: [3,1] → shown as "3 → 1")
   expect(screen.getByText(/3 → 1/)).toBeInTheDocument();
+  // Wait for initial history fetch to complete so we don't leak state updates
+  const api = await import('@/lib/api/client');
+  await waitFor(() => expect(api.getDiceHistory).toHaveBeenCalled());
   });
 });

--- a/frontend/__tests__/layout.test.tsx
+++ b/frontend/__tests__/layout.test.tsx
@@ -1,24 +1,29 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { describe, test, expect, vi } from 'vitest';
 
-// Mock aliases for single-file runs
 vi.mock('@/components/auth', () => ({
   AuthProvider: ({ children }: any) => <div data-testid="auth-provider">{children}</div>,
 }));
 
-// Mock global CSS before importing the real layout to avoid PostCSS running in tests
 vi.mock('../app/globals.css', () => ({}));
 import RootLayout from '../app/layout';
 
 describe('RootLayout', () => {
-  test('renders children inside AuthProvider', () => {
-    render(
-      <RootLayout>
-        <div>child-content</div>
-      </RootLayout>
-    );
+  test('renders children inside AuthProvider', async () => {
+    let c;
+    await act(async () => {
+      // Must use document because RootLayout renders <html> and you can't put <html> inside <div>.
+      const res = render(
+        <RootLayout>
+          <div>child-content</div>
+        </RootLayout>,
+        { container: document }
+      );
+      c = res.container;
+      await new Promise(r => setTimeout(r, 0));
+    });
 
     expect(screen.getByText('child-content')).toBeInTheDocument();
   });

--- a/frontend/__tests__/layout.test.tsx
+++ b/frontend/__tests__/layout.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { describe, test, expect, vi } from 'vitest';
 
 vi.mock('@/components/auth', () => ({
@@ -12,17 +12,15 @@ import RootLayout from '../app/layout';
 
 describe('RootLayout', () => {
   test('renders children inside AuthProvider', async () => {
-    let c;
-    await act(async () => {
+        await act(async () => {
       // Must use document because RootLayout renders <html> and you can't put <html> inside <div>.
-      const res = render(
+      render(
         <RootLayout>
           <div>child-content</div>
         </RootLayout>,
         { container: document }
       );
-      c = res.container;
-      await new Promise(r => setTimeout(r, 0));
+            await new Promise(r => setTimeout(r, 0));
     });
 
     expect(screen.getByText('child-content')).toBeInTheDocument();

--- a/frontend/__tests__/tolerancecalculator_additional.test.tsx
+++ b/frontend/__tests__/tolerancecalculator_additional.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 // Mock API client
@@ -36,24 +37,24 @@ describe('ToleranceCalculator additional interactions', () => {
     const beforeRows = within(table).getAllByRole('row').length;
 
     // add another intake
-    fireEvent.click(addBtn);
+    await act(async () => { fireEvent.click(addBtn); });
     const afterAddRows = within(table).getAllByRole('row').length;
     expect(afterAddRows).toBeGreaterThan(beforeRows);
 
     // there should now be a Remove button for the new row; click it
     const removeBtns = screen.getAllByText('Remove');
     expect(removeBtns.length).toBeGreaterThan(0);
-    fireEvent.click(removeBtns[removeBtns.length - 1]);
+    await act(async () => { fireEvent.click(removeBtns[removeBtns.length - 1]); });
 
     const afterRemoveRows = within(table).getAllByRole('row').length;
     expect(afterRemoveRows).toBe(beforeRows);
 
     // interact with the datetime-local input and intake type select to cover their handlers
   const datetime = within(table).getAllByDisplayValue(() => true).find((el) => el.getAttribute('type') === 'datetime-local');
-    if (datetime) fireEvent.change(datetime, { target: { value: '2025-01-01T12:00' } });
+    if (datetime) await act(async () => { fireEvent.change(datetime, { target: { value: '2025-01-01T12:00' } }); });
 
     const intakeTypeSelect = within(table).getAllByRole('combobox').find((s) => s.tagName === 'SELECT');
-    if (intakeTypeSelect) fireEvent.change(intakeTypeSelect, { target: { value: 'inhaled' } });
+    if (intakeTypeSelect) await act(async () => { fireEvent.change(intakeTypeSelect, { target: { value: 'inhaled' } }); });
   });
 
   it('logs an error if getToleranceSubstances fails (covers loadSubstances catch branch)', async () => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -96,3 +96,13 @@ vi.mock('*.css', () => ({}));
 vi.mock('*.scss', () => ({}));
 vi.mock('*.module.css', () => ({}));
 vi.mock('*.module.scss', () => ({}));
+
+import { afterEach, vi } from 'vitest';
+import { act } from '@testing-library/react';
+
+// Global teardown to cleanly flush any remaining async state updates
+afterEach(async () => {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+});


### PR DESCRIPTION
Resolves the `act(...)` console warnings generated by Vitest without relying on hacks or console suppressions. This is achieved by ensuring that mocked API requests wait for DOM assertions, using `act()` correctly around renders, and tracking down implicit async side effects like `next/link` prefetching.

---
*PR created automatically by Jules for task [2436032616687245130](https://jules.google.com/task/2436032616687245130) started by @Ch3fUlrich*