### PR TITLE
🧪 test: add coverage for backendStatus online/offline tracking

### DIFF
--- a/frontend/__tests__/backendStatus.test.ts
+++ b/frontend/__tests__/backendStatus.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  markBackendOnline,
+  markBackendOffline,
+  getBackendStatus,
+  isBackendOffline,
+  subscribeBackendStatus,
+  resetBackendStatusForTests,
+} from '../lib/api/backendStatus';
+
+describe('backendStatus state transitions', () => {
+  beforeEach(() => {
+    resetBackendStatusForTests();
+  });
+
+  it('should initially have "unknown" status', () => {
+    expect(getBackendStatus()).toBe('unknown');
+    expect(isBackendOffline()).toBe(false);
+  });
+
+  it('should mark backend offline and update status to "offline"', () => {
+    markBackendOffline();
+    expect(getBackendStatus()).toBe('offline');
+    expect(isBackendOffline()).toBe(true);
+  });
+
+  it('should mark backend online and update status to "online"', () => {
+    markBackendOnline();
+    expect(getBackendStatus()).toBe('online');
+    expect(isBackendOffline()).toBe(false);
+  });
+
+  it('should notify listeners when status changes', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeBackendStatus(listener);
+
+    markBackendOffline();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    markBackendOnline();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('should not notify listeners if status does not change', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeBackendStatus(listener);
+
+    // Initial state is 'unknown'. Setting it to 'unknown' (if we had a generic setter) wouldn't trigger it.
+    // Setting to offline triggers it once.
+    markBackendOffline();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Setting it to offline again should not trigger the listener again.
+    markBackendOffline();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `backendStatus.ts` module to cover online/offline state tracking, specifically targeting the `markBackendOnline` and `markBackendOffline` functions.
📊 **Coverage:** Covered initial state (`unknown`), transitions to `offline` and `online`, listener notification upon state changes, and verification that listeners are not notified redundantly if the status doesn't change.
✨ **Result:** Improved test coverage for frontend backend state management, ensuring transitions and hooks that depend on backend status work correctly.

---
*PR created automatically by Jules for task [5078931552837681472](https://jules.google.com/task/5078931552837681472) started by @Ch3fUlrich*