### PR TITLE
🔒 Fix insecure random number generation in dice utility

### DIFF
--- a/frontend/lib/local/dice.ts
+++ b/frontend/lib/local/dice.ts
@@ -22,19 +22,18 @@ const DIE_SIDES: Record<string, number> = {
 /** Unbiased random integer in [1, sides] via CSPRNG rejection sampling. */
 function randomDieValue(sides: number): number {
   const cryptoObj = globalThis.crypto;
-  if (cryptoObj?.getRandomValues) {
-    // Largest multiple of `sides` below 2^32 — reject values above it.
-    const limit = Math.floor(0x1_0000_0000 / sides) * sides;
-    const buf = new Uint32Array(1);
-    let x: number;
-    do {
-      cryptoObj.getRandomValues(buf);
-      x = buf[0];
-    } while (x >= limit);
-    return 1 + (x % sides);
+  if (!cryptoObj || typeof cryptoObj.getRandomValues !== 'function') {
+    throw new Error('Secure random number generation is not supported in this environment');
   }
-  // Environments without Web Crypto (old test runners) — non-cryptographic fallback.
-  return 1 + Math.floor(Math.random() * sides);
+  // Largest multiple of `sides` below 2^32 — reject values above it.
+  const limit = Math.floor(0x1_0000_0000 / sides) * sides;
+  const buf = new Uint32Array(1);
+  let x: number;
+  do {
+    cryptoObj.getRandomValues(buf);
+    x = buf[0];
+  } while (x >= limit);
+  return 1 + (x % sides);
 }
 
 function median(sorted: number[]): number {


### PR DESCRIPTION
🎯 **What:** Fixed an insecure random number generation vulnerability in the dice utility where the code fell back to `Math.random()`.
⚠️ **Risk:** The use of `Math.random()` generates cryptographically insecure pseudorandom numbers, which compromises unpredictability. In a dice rolling tool, an attacker could predict upcoming results or manipulate behavior if they can determine the PRNG state.
🛡️ **Solution:** Removed the `Math.random()` fallback entirely. The method now throws an explicit error if `globalThis.crypto.getRandomValues` (CSPRNG) is unavailable, ensuring the application fails securely instead of degrading to predictable random number generation.

---
*PR created automatically by Jules for task [12073942324996801739](https://jules.google.com/task/12073942324996801739) started by @Ch3fUlrich*