### PR TITLE
🧹 refactor(backend): remove dead code allowance from filter params

### DIFF
--- a/backend/src/api/training.rs
+++ b/backend/src/api/training.rs
@@ -20,19 +20,14 @@ pub struct PaginationParams {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct StatsFilterParams {
     pub from: Option<String>,
     pub to: Option<String>,
-    pub plan_id: Option<String>,
-    pub exercise_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct ExerciseFilterParams {
     pub equipment: Option<String>,
-    pub muscle: Option<String>,
     pub pattern: Option<String>,
     pub difficulty: Option<String>,
     pub search: Option<String>,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed `#[allow(dead_code)]` from `StatsFilterParams` and `ExerciseFilterParams` and deleted their unused fields (`plan_id`, `exercise_id`, `muscle`).

💡 **Why:** How this improves maintainability
Removing dead code and dead code allowances improves codebase readability and maintainability. It prevents developers from wondering why certain fields exist if they aren't used anywhere, and ensures compiler warnings are resolved through proper code hygiene rather than suppression.

✅ **Verification:** How you confirmed the change is safe
Ran `cargo check` and `cargo test`. All checks and tests passed. The removed fields were confirmed to be genuinely unused elsewhere in the file/project.

✨ **Result:** The improvement achieved
Cleaned up structs and removed compiler suppressions without altering behavior.

---
*PR created automatically by Jules for task [12489982841337503454](https://jules.google.com/task/12489982841337503454) started by @Ch3fUlrich*