### PR TITLE
🧹 [code health] Remove dead code allowance in n26_analyzer

### DIFF
--- a/backend/src/api/n26_analyzer.rs
+++ b/backend/src/api/n26_analyzer.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::tools::n26_analyzer::{analyze_transactions, parse_n26_json, N26Data};
 use axum::{
     extract::Json,

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -30,6 +30,7 @@ pub fn build_app(
         .route("/healthz", get(health_check))
         .route("/api/health", get(health_check))
         .route("/api/tools/fat-loss", post(crate::api::fat_loss::calculate_fat_loss))
+        .route("/api/tools/n26-analyzer", post(crate::api::n26_analyzer::analyze_n26_data))
         .route("/api/tools/bloodlevel/calculate", post(crate::api::bloodlevel::calculate_tolerance))
         .route("/api/tools/bloodlevel/substances", get(crate::api::bloodlevel::get_substances))
         .route("/api/tools/dice/roll", post(crate::api::dice::roll))


### PR DESCRIPTION
🎯 **What:** Removed `#![allow(dead_code)]` from `backend/src/api/n26_analyzer.rs` and properly hooked up the unused `analyze_n26_data` handler to the Axum router in `backend/src/app.rs`.
💡 **Why:** To improve code health by removing compiler warning suppression and properly utilizing the implemented endpoint, ensuring the code is reachable and maintainable.
✅ **Verification:** Verified by running `cargo check` and `cargo test` in the backend, confirming there are no warnings and all tests pass.
✨ **Result:** The code health issue is resolved, code is cleaner, and no dead code warning exists since the handler is now routed.

---
*PR created automatically by Jules for task [16303224180609394814](https://jules.google.com/task/16303224180609394814) started by @Ch3fUlrich*