### PR TITLE
🧹 Code Health: Remove unused dead code from SubstanceIntake

### DIFF
--- a/backend/src/tools/bloodlevel.rs
+++ b/backend/src/tools/bloodlevel.rs
@@ -2,12 +2,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
+
 pub struct SubstanceIntake {
     pub substance: String,
     pub time: DateTime<Utc>,
-    pub intake_type: String, // e.g., "oral", "intravenous", "inhaled"
-    pub time_after_meal: Option<i32>, // minutes after meal, affects absorption
     pub dosage_mg: f64,
 }
 

--- a/backend/tests/more_unit_coverage.rs
+++ b/backend/tests/more_unit_coverage.rs
@@ -8,8 +8,6 @@ async fn test_bloodlevel_single_intake_amount_positive() {
     let intake = SubstanceIntake {
         substance: "Caffeine".to_string(),
         time: now - chrono::Duration::hours(1),
-        intake_type: "oral".to_string(),
-        time_after_meal: None,
         dosage_mg: 100.0,
     };
 
@@ -26,8 +24,6 @@ async fn test_bloodlevel_future_intake_skipped() {
     let intake = SubstanceIntake {
         substance: "Caffeine".to_string(),
         time: now + chrono::Duration::hours(1),
-        intake_type: "oral".to_string(),
-        time_after_meal: None,
         dosage_mg: 100.0,
     };
 
@@ -44,8 +40,6 @@ async fn test_bloodlevel_missing_substance_error() {
     let intake = SubstanceIntake {
         substance: "NotARealDrug".to_string(),
         time: now - chrono::Duration::hours(1),
-        intake_type: "oral".to_string(),
-        time_after_meal: None,
         dosage_mg: 50.0,
     };
 

--- a/frontend/__tests__/local_compute.test.ts
+++ b/frontend/__tests__/local_compute.test.ts
@@ -101,7 +101,7 @@ describe('local blood level calculation', () => {
     const t0 = '2026-01-01T00:00:00.000Z';
     const oneHalfLifeLater = '2026-01-01T05:42:00.000Z'; // caffeine t1/2 = 5.7 h
     const res = calculateToleranceLocal({
-      intakes: [{ substance: 'caffeine', time: t0, intake_type: 'oral', time_after_meal: null, dosage_mg: 100 }],
+      intakes: [{ substance: 'caffeine', time: t0, dosage_mg: 100 }],
       time_points: [t0, oneHalfLifeLater],
     });
     expect(res.blood_levels).toHaveLength(2);
@@ -115,15 +115,15 @@ describe('local blood level calculation', () => {
     const t0 = '2026-01-01T12:00:00.000Z';
     const res = calculateToleranceLocal({
       intakes: [
-        { substance: 'Alcohol (Ethanol)', time: t0, intake_type: 'oral', time_after_meal: null, dosage_mg: 100 },
-        { substance: 'Alcohol (Ethanol)', time: '2026-01-02T00:00:00.000Z', intake_type: 'oral', time_after_meal: null, dosage_mg: 100 },
+        { substance: 'Alcohol (Ethanol)', time: t0, dosage_mg: 100 },
+        { substance: 'Alcohol (Ethanol)', time: '2026-01-02T00:00:00.000Z', dosage_mg: 100 },
       ],
       time_points: [t0],
     });
     expect(res.blood_levels[0].amount_mg).toBeCloseTo(100, 6); // only the past intake counts
 
     const byId = calculateToleranceLocal({
-      intakes: [{ substance: 'alcohol', time: t0, intake_type: 'oral', time_after_meal: null, dosage_mg: 100 }],
+      intakes: [{ substance: 'alcohol', time: t0, dosage_mg: 100 }],
       time_points: [t0],
     });
     expect(byId.blood_levels[0].amount_mg).toBeCloseTo(100, 6);
@@ -132,7 +132,7 @@ describe('local blood level calculation', () => {
   it('throws for unknown substances like the backend', () => {
     expect(() =>
       calculateToleranceLocal({
-        intakes: [{ substance: 'unobtainium', time: '2026-01-01T00:00:00Z', intake_type: 'oral', time_after_meal: null, dosage_mg: 1 }],
+        intakes: [{ substance: 'unobtainium', time: '2026-01-01T00:00:00Z', dosage_mg: 1 }],
         time_points: ['2026-01-01T00:00:00Z'],
       }),
     ).toThrow(/not found in database/);

--- a/frontend/components/tools/BloodLevelCalculator.tsx
+++ b/frontend/components/tools/BloodLevelCalculator.tsx
@@ -99,8 +99,6 @@ const BloodLevelCalculator: React.FC = () => {
           .map(intake => ({
             substance: intake.substance,
             time: intake.time,
-            intake_type: intake.intakeType,
-            time_after_meal: intake.timeAfterMeal,
             dosage_mg: intake.dosageMg,
           })),
         time_points: timePoints,

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -361,8 +361,6 @@ export interface Substance {
 export interface SubstanceIntakeRequest {
   substance: string;
   time: string;
-  intake_type: string;
-  time_after_meal: number | null;
   dosage_mg: number;
 }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the `#[allow(dead_code)]` macro from `SubstanceIntake` in `backend/src/tools/bloodlevel.rs` and removed the unused `intake_type` and `time_after_meal` fields. Updated all backend tests and frontend API/components that sent or used these fields.

💡 **Why:** How this improves maintainability
The fields were never read on the backend, creating compiler warnings and technical debt. By removing them, the codebase strictly matches what it consumes and is easier to understand, with fewer moving pieces.

✅ **Verification:** How you confirmed the change is safe
Ran full backend (`cargo test`) and frontend (`pnpm --filter frontend test --run`) test suites. All tests passed, confirming no logic relied on these fields.

✨ **Result:** The improvement achieved
A cleaner `SubstanceIntake` model, zero dead code warnings, and correctly aligned frontend API payloads.

---
*PR created automatically by Jules for task [16242106025610966626](https://jules.google.com/task/16242106025610966626) started by @Ch3fUlrich*