### PR TITLE
🧹 [code health improvement] Remove dead code allowance and unused fields

### DIFF
--- a/backend/src/api/training.rs
+++ b/backend/src/api/training.rs
@@ -20,19 +20,14 @@ pub struct PaginationParams {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct StatsFilterParams {
     pub from: Option<String>,
     pub to: Option<String>,
-    pub plan_id: Option<String>,
-    pub exercise_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct ExerciseFilterParams {
     pub equipment: Option<String>,
-    pub muscle: Option<String>,
     pub pattern: Option<String>,
     pub difficulty: Option<String>,
     pub search: Option<String>,


### PR DESCRIPTION
🎯 **What:** Removed `#[allow(dead_code)]` from `StatsFilterParams` and `ExerciseFilterParams` in `backend/src/api/training.rs`, and removed the unused fields `plan_id`, `exercise_id`, and `muscle`.
💡 **Why:** This improves the maintainability and readability of the codebase by keeping struct definitions clean and free of unused fields, making it clear which parameters are actively consumed.
✅ **Verification:** Ran `cargo check` and `cargo test` in the `backend` directory to ensure no new warnings were introduced and all tests pass.
✨ **Result:** A cleaner codebase with correctly structured query parameter deserialization structs.

---
*PR created automatically by Jules for task [14895031697472157110](https://jules.google.com/task/14895031697472157110) started by @Ch3fUlrich*