### PR TITLE
🧹 refactor(backend): remove dead code `history_key` in session store

### DIFF
--- a/backend/src/tools/session.rs
+++ b/backend/src/tools/session.rs
@@ -319,13 +319,6 @@ impl SessionStore {
         Ok(result)
     }
 
-    // Helper for naming history key for sid
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn history_key(&self, sid: &str) -> String {
-        format!("{}:history:{}", self.namespace, sid)
-    }
-
     // Sliding-window rate limiter using a Redis sorted set keyed by provided key.
     // Adds an entry with score == current unix seconds and trims entries older than window_secs.
     // Returns Ok(true) if the number of entries after adding is <= limit, otherwise false.


### PR DESCRIPTION
🎯 **What:** Removed the unused `history_key` function and its `#[allow(dead_code)]` annotation in `backend/src/tools/session.rs`.
💡 **Why:** Removes dead code and compiler warning suppressions to keep the codebase clean and maintainable.
✅ **Verification:** Verified by compiling the backend code (`cargo check`) and running all tests (`cargo test`) to ensure no regressions were introduced.
✨ **Result:** A cleaner session store without unnecessary code or warnings.

---
*PR created automatically by Jules for task [13769695156061546927](https://jules.google.com/task/13769695156061546927) started by @Ch3fUlrich*