### PR TITLE
🧹 Refactor: Reduce file complexity in DiceRoller

### DIFF
--- a/frontend/components/tools/DiceRoller.tsx
+++ b/frontend/components/tools/DiceRoller.tsx
@@ -14,147 +14,19 @@ import Boxplot from '../charts/Boxplot';
 import Histogram from '../charts/Histogram';
 import type { DiceResponse, DiceRequest } from '../../lib/types/dice';
 
-const LS_HISTORY_KEY = 'dice_history_local';
-
-function loadLocalHistory(): Array<{ time: string; summary?: { sum?: number }; details?: unknown[] }> {
-  if (typeof window === 'undefined') return [];
-  try {
-    return JSON.parse(localStorage.getItem(LS_HISTORY_KEY) || '[]');
-  } catch {
-    return [];
-  }
-}
-
-function saveLocalHistory(entries: Array<{ time: string; summary?: { sum?: number }; details?: unknown[] }>) {
-  if (typeof window === 'undefined') return;
-  try {
-    localStorage.setItem(LS_HISTORY_KEY, JSON.stringify(entries.slice(0, 50)));
-  } catch {
-    // storage full or unavailable — ignore
-  }
-}
-
-type PerDie = {
-  original: number[];
-  final: number;
-};
-
-type RollDetail = {
-  sum: number;
-  average: number;
-  perDie: PerDie[];
-  used: number[];
-  rerollCount?: number;
-  rerollConfig?: string;
-  rawSum?: number;       // sum of dice before modifier
-  totalModifier?: number; // flat group modifier (+/-)
-};
-
-type DieOption = 'd2'|'d3'|'d4'|'d6'|'d8'|'d10'|'d12'|'d20'|'custom';
-
-type DiceConfig = {
-  id: string;
-  dieType: DieOption;
-  sides: number;
-  count: number;
-  // per-die local modifiers
-  numericModifier?: number;
-  advantage?: 'none' | 'adv' | 'dis';
-  rerollEnabled?: boolean;
-  rerollOperator?: '<'|'>'|'=';
-  rerollValue?: number;
-  rerollValuesStr?: string;  // comma-separated values for '=' operator
-  customName?: string;
-};
-
-// DIE_FACES was removed — we now display a consistent die emoji in the dropdown labels (e.g. "🎲 D6 (6)").
-
-// Returns "D6" for a unique die type, or "1. D6" / "2. D6" when multiple configs share the same sides
-function getDieLabel(rollIndex: number, configs: DiceConfig[]): string {
-  const cfgIndex = Math.min(rollIndex, configs.length - 1);
-  const sides = configs[cfgIndex]?.sides ?? 6;
-  const typeName = `D${sides}`;
-  const sameTypeIndexes = configs.map((c, j) => (c.sides === sides ? j : -1)).filter(j => j >= 0);
-  if (sameTypeIndexes.length > 1) {
-    const rank = sameTypeIndexes.indexOf(cfgIndex) + 1;
-    return `${rank}. ${typeName}`;
-  }
-  return typeName;
-}
-
-// Returns customName if set, otherwise getDieLabel
-function getDisplayLabel(idx: number, configs: DiceConfig[]): string {
-  const cfg = configs[Math.min(idx, configs.length - 1)];
-  if (cfg?.customName) return cfg.customName;
-  return getDieLabel(idx, configs);
-}
-
-// Compute exact probability distribution for numDice×sides using dynamic programming
-function computeSumDist(numDice: number, sides: number): Map<number, number> {
-  let dist = new Map<number, number>([[0, 1]]);
-  for (let d = 0; d < numDice; d++) {
-    const next = new Map<number, number>();
-    for (const [s, w] of dist) {
-      for (let f = 1; f <= sides; f++) {
-        const ns = s + f;
-        next.set(ns, (next.get(ns) ?? 0) + w);
-      }
-    }
-    dist = next;
-  }
-  return dist;
-}
-
-// Parse comma-separated reroll values string into number array
-function parseRerollValues(str: string): number[] {
-  return str.split(',').map(s => s.trim()).filter(s => s !== '').map(Number).filter(n => Number.isFinite(n));
-}
-
-// Build reroll condition function from config; returns null if reroll not applicable
-function buildRerollCondition(cfg: DiceConfig): ((val: number) => boolean) | null {
-  if (!cfg.rerollEnabled) return null;
-  const op = cfg.rerollOperator || '<';
-  if (op === '=') {
-    const vals = new Set(parseRerollValues(cfg.rerollValuesStr || ''));
-    return vals.size > 0 ? (v: number) => vals.has(v) : null;
-  }
-  if (!Number.isFinite(cfg.rerollValue ?? NaN)) return null;
-  const rv = cfg.rerollValue as number;
-  if (op === '<') return (v: number) => v < rv;
-  if (op === '>') return (v: number) => v > rv;
-  return null;
-}
-
-// Build display string for reroll config (e.g. "< 3" or "= 1, 6")
-function buildRerollConfigStr(cfg: DiceConfig): string {
-  if (!cfg.rerollEnabled) return '';
-  const op = cfg.rerollOperator || '<';
-  if (op === '=') {
-    const vals = parseRerollValues(cfg.rerollValuesStr || '');
-    return vals.length > 0 ? `= ${vals.join(', ')}` : '';
-  }
-  return Number.isFinite(cfg.rerollValue ?? NaN) ? `${op} ${cfg.rerollValue}` : '';
-}
-
-// Compute set of sums achievable using only non-rerollable face values (for prob chart graying)
-function computeCleanSums(numDice: number, sides: number, isRerollable: (v: number) => boolean): Set<number> {
-  const cleanFaces: number[] = [];
-  for (let f = 1; f <= sides; f++) {
-    if (!isRerollable(f)) cleanFaces.push(f);
-  }
-  if (cleanFaces.length === 0) return new Set();
-  let sums = new Set<number>([0]);
-  for (let d = 0; d < numDice; d++) {
-    const next = new Set<number>();
-    for (const s of sums) {
-      for (const f of cleanFaces) {
-        next.add(s + f);
-      }
-    }
-    sums = next;
-  }
-  return sums;
-}
+import {
+  LS_HISTORY_KEY,
+  loadLocalHistory,
+  saveLocalHistory,
+  getDisplayLabel,
+  buildRerollCondition,
+  buildRerollConfigStr,
+} from './dice/utils';
+import {
+  computeSumDist,
+  computeCleanSums,
+} from './dice/stats';
+import type { DiceConfig, RollDetail, DieOption, PerDie } from './dice/types';
 
 export const DiceRoller: React.FC = () => {
   const [diceConfigs, setDiceConfigs] = useState<DiceConfig[]>([

--- a/frontend/components/tools/dice/stats.ts
+++ b/frontend/components/tools/dice/stats.ts
@@ -1,0 +1,35 @@
+// Compute exact probability distribution for numDice×sides using dynamic programming
+export function computeSumDist(numDice: number, sides: number): Map<number, number> {
+  let dist = new Map<number, number>([[0, 1]]);
+  for (let d = 0; d < numDice; d++) {
+    const next = new Map<number, number>();
+    for (const [s, w] of dist) {
+      for (let f = 1; f <= sides; f++) {
+        const ns = s + f;
+        next.set(ns, (next.get(ns) ?? 0) + w);
+      }
+    }
+    dist = next;
+  }
+  return dist;
+}
+
+// Compute set of sums achievable using only non-rerollable face values (for prob chart graying)
+export function computeCleanSums(numDice: number, sides: number, isRerollable: (v: number) => boolean): Set<number> {
+  const cleanFaces: number[] = [];
+  for (let f = 1; f <= sides; f++) {
+    if (!isRerollable(f)) cleanFaces.push(f);
+  }
+  if (cleanFaces.length === 0) return new Set();
+  let sums = new Set<number>([0]);
+  for (let d = 0; d < numDice; d++) {
+    const next = new Set<number>();
+    for (const s of sums) {
+      for (const f of cleanFaces) {
+        next.add(s + f);
+      }
+    }
+    sums = next;
+  }
+  return sums;
+}

--- a/frontend/components/tools/dice/types.ts
+++ b/frontend/components/tools/dice/types.ts
@@ -1,0 +1,32 @@
+export type PerDie = {
+  original: number[];
+  final: number;
+};
+
+export type RollDetail = {
+  sum: number;
+  average: number;
+  perDie: PerDie[];
+  used: number[];
+  rerollCount?: number;
+  rerollConfig?: string;
+  rawSum?: number;       // sum of dice before modifier
+  totalModifier?: number; // flat group modifier (+/-)
+};
+
+export type DieOption = 'd2'|'d3'|'d4'|'d6'|'d8'|'d10'|'d12'|'d20'|'custom';
+
+export type DiceConfig = {
+  id: string;
+  dieType: DieOption;
+  sides: number;
+  count: number;
+  // per-die local modifiers
+  numericModifier?: number;
+  advantage?: 'none' | 'adv' | 'dis';
+  rerollEnabled?: boolean;
+  rerollOperator?: '<'|'>'|'=';
+  rerollValue?: number;
+  rerollValuesStr?: string;  // comma-separated values for '=' operator
+  customName?: string;
+};

--- a/frontend/components/tools/dice/utils.ts
+++ b/frontend/components/tools/dice/utils.ts
@@ -1,0 +1,72 @@
+import { DiceConfig } from './types';
+
+export const LS_HISTORY_KEY = 'dice_history_local';
+
+export function loadLocalHistory(): Array<{ time: string; summary?: { sum?: number }; details?: unknown[] }> {
+  if (typeof window === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem(LS_HISTORY_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+export function saveLocalHistory(entries: Array<{ time: string; summary?: { sum?: number }; details?: unknown[] }>) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(LS_HISTORY_KEY, JSON.stringify(entries.slice(0, 50)));
+  } catch {
+    // storage full or unavailable — ignore
+  }
+}
+
+// Returns "D6" for a unique die type, or "1. D6" / "2. D6" when multiple configs share the same sides
+export function getDieLabel(rollIndex: number, configs: DiceConfig[]): string {
+  const cfgIndex = Math.min(rollIndex, configs.length - 1);
+  const sides = configs[cfgIndex]?.sides ?? 6;
+  const typeName = `D${sides}`;
+  const sameTypeIndexes = configs.map((c, j) => (c.sides === sides ? j : -1)).filter(j => j >= 0);
+  if (sameTypeIndexes.length > 1) {
+    const rank = sameTypeIndexes.indexOf(cfgIndex) + 1;
+    return `${rank}. ${typeName}`;
+  }
+  return typeName;
+}
+
+// Returns customName if set, otherwise getDieLabel
+export function getDisplayLabel(idx: number, configs: DiceConfig[]): string {
+  const cfg = configs[Math.min(idx, configs.length - 1)];
+  if (cfg?.customName) return cfg.customName;
+  return getDieLabel(idx, configs);
+}
+
+// Parse comma-separated reroll values string into number array
+export function parseRerollValues(str: string): number[] {
+  return str.split(',').map(s => s.trim()).filter(s => s !== '').map(Number).filter(n => Number.isFinite(n));
+}
+
+// Build reroll condition function from config; returns null if reroll not applicable
+export function buildRerollCondition(cfg: DiceConfig): ((val: number) => boolean) | null {
+  if (!cfg.rerollEnabled) return null;
+  const op = cfg.rerollOperator || '<';
+  if (op === '=') {
+    const vals = new Set(parseRerollValues(cfg.rerollValuesStr || ''));
+    return vals.size > 0 ? (v: number) => vals.has(v) : null;
+  }
+  if (!Number.isFinite(cfg.rerollValue ?? NaN)) return null;
+  const rv = cfg.rerollValue as number;
+  if (op === '<') return (v: number) => v < rv;
+  if (op === '>') return (v: number) => v > rv;
+  return null;
+}
+
+// Build display string for reroll config (e.g. "< 3" or "= 1, 6")
+export function buildRerollConfigStr(cfg: DiceConfig): string {
+  if (!cfg.rerollEnabled) return '';
+  const op = cfg.rerollOperator || '<';
+  if (op === '=') {
+    const vals = parseRerollValues(cfg.rerollValuesStr || '');
+    return vals.length > 0 ? `= ${vals.join(', ')}` : '';
+  }
+  return Number.isFinite(cfg.rerollValue ?? NaN) ? `${op} ${cfg.rerollValue}` : '';
+}

--- a/frontend/components/tools/dice/utils.ts
+++ b/frontend/components/tools/dice/utils.ts
@@ -1,3 +1,4 @@
+/* global window, localStorage */
 import { DiceConfig } from './types';
 
 export const LS_HISTORY_KEY = 'dice_history_local';


### PR DESCRIPTION
🎯 **What:** Extracted types, pure functions, and statistical math logic from `frontend/components/tools/DiceRoller.tsx` into a new `frontend/components/tools/dice` subdirectory (`types.ts`, `utils.ts`, and `stats.ts`).
💡 **Why:** `DiceRoller.tsx` was a very large and complex file (764 lines). This change improves maintainability and readability by moving approximately 130 lines of complex logic and types into clean and reusable modules.
✅ **Verification:** Verified by successfully running `pnpm --filter frontend test --run` and `pnpm --filter frontend run lint` to ensure no functionality is broken.
✨ **Result:** Improved code health and file structure without changing any application behavior.

---
*PR created automatically by Jules for task [15627469869422465201](https://jules.google.com/task/15627469869422465201) started by @Ch3fUlrich*