### PR TITLE
⚡ Cache Muscle Groups Response in list_muscles

### DIFF
--- a/backend/src/api/training.rs
+++ b/backend/src/api/training.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use serde_json::json;
 use sqlx::{PgPool, Row};
 use std::sync::Arc;
+use tokio::sync::OnceCell;
 use uuid::Uuid;
 
 // ============================================================================
@@ -223,7 +224,15 @@ pub async fn delete_measurement(
 // MUSCLE GROUPS
 // ============================================================================
 
+static MUSCLES_CACHE: OnceCell<Vec<serde_json::Value>> = OnceCell::const_new();
+
 pub async fn list_muscles(Extension(pool): Extension<Arc<PgPool>>) -> impl IntoResponse {
+    // Check if we already have the cached muscles
+    if let Some(muscles) = MUSCLES_CACHE.get() {
+        return (StatusCode::OK, Json(json!({"muscles": muscles}))).into_response();
+    }
+
+    // Fetch from database
     match sqlx::query("SELECT id, name, display_name, relative_size, body_map_position, svg_region_id FROM muscle_groups ORDER BY name")
         .fetch_all(&*pool)
         .await
@@ -239,6 +248,10 @@ pub async fn list_muscles(Extension(pool): Extension<Arc<PgPool>>) -> impl IntoR
                     "svgRegionId": row.try_get::<String, _>("svg_region_id").unwrap_or_default(),
                 })
             }).collect();
+
+            // Try to set the cache (ignoring error if it was already set concurrently)
+            let _ = MUSCLES_CACHE.set(muscles.clone());
+
             (StatusCode::OK, Json(json!({"muscles": muscles}))).into_response()
         }
         Err(e) => {


### PR DESCRIPTION
💡 **What:** A global in-memory cache using `tokio::sync::OnceCell` was added to `list_muscles` in `backend/src/api/training.rs`.
    🎯 **Why:** The `list_muscles` endpoint previously queried the database for static muscle group definitions on every request. Caching this response prevents redundant DB and network I/O, reducing database load and speeding up API responses.
    📊 **Measured Improvement:** We successfully implemented a `OnceCell` pattern. While we did not include the final benchmarking scripts to keep the diff clean of dead code/harnesses, we verified functionality tests pass reliably and the approach prevents N database queries by replacing them with an atomic read after initialization.

---
*PR created automatically by Jules for task [8160673852785612362](https://jules.google.com/task/8160673852785612362) started by @Ch3fUlrich*