### PR TITLE
🧹 refactor(backend): remove allow(dead_code) from n26 analyzer

### DIFF
--- a/backend/src/api/n26_analyzer.rs
+++ b/backend/src/api/n26_analyzer.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::tools::n26_analyzer::{analyze_transactions, parse_n26_json, N26Data};
 use axum::{
     extract::Json,

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -30,6 +30,7 @@ pub fn build_app(
         .route("/healthz", get(health_check))
         .route("/api/health", get(health_check))
         .route("/api/tools/fat-loss", post(crate::api::fat_loss::calculate_fat_loss))
+        .route("/api/tools/n26-analyzer", post(crate::api::n26_analyzer::analyze_n26_data))
         .route("/api/tools/bloodlevel/calculate", post(crate::api::bloodlevel::calculate_tolerance))
         .route("/api/tools/bloodlevel/substances", get(crate::api::bloodlevel::get_substances))
         .route("/api/tools/dice/roll", post(crate::api::dice::roll))

--- a/backend/src/tools/n26_analyzer.rs
+++ b/backend/src/tools/n26_analyzer.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 


### PR DESCRIPTION
* 🎯 **What:** Removed the `#![allow(dead_code)]` macro from `n26_analyzer.rs` and fixed the underlying cause by correctly registering the `/api/tools/n26-analyzer` route in the Axum app router.
* 💡 **Why:** By connecting the orphaned route to the main router, the compiler now correctly sees the handler, its tool functions, and associated structs as used. This resolves the warnings cleanly and restores the API endpoint's functionality without deleting working code.
* ✅ **Verification:** Re-ran `cargo clippy -- -D warnings` and `cargo test` in the `backend/` directory to ensure the compilation is clean and all tests still pass.
* ✨ **Result:** Dead code warnings are resolved legitimately, maintaining better code health, readability, and compiler checking moving forward.

---
*PR created automatically by Jules for task [1387498177247913232](https://jules.google.com/task/1387498177247913232) started by @Ch3fUlrich*