### PR TITLE
⚡ Optimize frontend DiceRoller API calls with batched requests

### DIFF
--- a/backend/src/api/dice.rs
+++ b/backend/src/api/dice.rs
@@ -17,14 +17,23 @@ lazy_static! {
         Mutex::new(HashMap::new());
 }
 
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RollPayload {
+    Single(dice_logic::DiceRequest),
+    Batch(Vec<dice_logic::DiceRequest>),
+}
+
 #[debug_handler]
 pub async fn roll(
     Extension(store): Extension<Option<Arc<AsyncMutex<SessionStore>>>>,
     headers: axum::http::HeaderMap,
     Json(payload): Json<JsonValue>,
 ) -> impl IntoResponse {
-    // Attempt to deserialize into DiceRequest
-    let req: dice_logic::DiceRequest = match serde_json::from_value(payload) {
+    // Attempt to deserialize into RollPayload
+    let payload_parsed: RollPayload = match serde_json::from_value(payload) {
         Ok(r) => r,
         Err(e) => {
             return (
@@ -94,8 +103,38 @@ pub async fn roll(
         }
     }
 
-    match dice_logic::handle_roll(req).await {
-        Ok(resp) => (axum::http::StatusCode::OK, axum::Json(resp)).into_response(),
-        Err(e) => (axum::http::StatusCode::BAD_REQUEST, axum::Json(e)).into_response(),
+    match payload_parsed {
+        RollPayload::Single(req) => match dice_logic::handle_roll(req).await {
+            Ok(resp) => (axum::http::StatusCode::OK, axum::Json(resp)).into_response(),
+            Err(e) => (axum::http::StatusCode::BAD_REQUEST, axum::Json(e)).into_response(),
+        },
+        RollPayload::Batch(reqs) => {
+            let mut all_rolls = Vec::new();
+            let mut total_requested = 0;
+
+            for req in reqs {
+                match dice_logic::handle_roll(req).await {
+                    Ok(mut resp) => {
+                        all_rolls.append(&mut resp.rolls);
+                        if let Some(summary) = resp.summary.as_object() {
+                            if let Some(count) =
+                                summary.get("totalRollsRequested").and_then(|v| v.as_u64())
+                            {
+                                total_requested += count;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        return (axum::http::StatusCode::BAD_REQUEST, axum::Json(e)).into_response()
+                    }
+                }
+            }
+
+            let combined_resp = dice_logic::DiceResponse {
+                rolls: all_rolls,
+                summary: serde_json::json!({ "totalRollsRequested": total_requested }),
+            };
+            (axum::http::StatusCode::OK, axum::Json(combined_resp)).into_response()
+        }
     }
 }

--- a/backend/tests/http_integration.rs
+++ b/backend/tests/http_integration.rs
@@ -48,6 +48,17 @@ async fn test_http_endpoints() {
         .await;
     assert!(resp.status_code().is_success());
 
+    // 2b) Test batch dice roll
+    let batch_body = r#"[{"die":{"type":"d20"},"count":1}, {"die":{"type":"d6"},"count":2}]"#;
+    let resp = server
+        .post("/api/tools/dice/roll")
+        .json(&serde_json::from_str::<serde_json::Value>(batch_body).unwrap())
+        .await;
+    assert!(resp.status_code().is_success());
+    let resp_json: serde_json::Value = resp.json();
+    assert_eq!(resp_json["rolls"].as_array().unwrap().len(), 2);
+    assert_eq!(resp_json["summary"]["totalRollsRequested"], 2);
+
     // 3) Save a roll (anonymous -> DB fallback)
     let body = r#"{"payload":{"http_test":true}}"#;
     let resp = server

--- a/frontend/__tests__/diceroller_additional_targeted.test.tsx
+++ b/frontend/__tests__/diceroller_additional_targeted.test.tsx
@@ -20,10 +20,15 @@ beforeEach(() => {
 
 describe('DiceRoller additional targeted branches', () => {
   it('applies per-config mapping for multiple configs and recalculates summary when second config modifies a die', async () => {
-    // API: first call returns a single roll with two perDie entries (so idx 0/1 map to cfg 0/1)
-    mockRollDice.mockResolvedValueOnce({ summary: { totalRollsRequested: 1 }, rolls: [ { sum: 5, average: 2.5, perDie: [{ original: [2], final: 2 }, { original: [3], final: 3 }], used: [2,3] } ] });
-    // second API call (for the second config) should also resolve to a valid shape (can be empty)
-    mockRollDice.mockResolvedValueOnce({ summary: { totalRollsRequested: 1 }, rolls: [ { sum: 0, average: 0, perDie: [], used: [] } ] });
+    // API returns a combined roll containing two rolls (one for each config due to batching mapping)
+    // First roll mapped to cfg 0, Second roll mapped to cfg 1
+    mockRollDice.mockResolvedValueOnce({
+      summary: { totalRollsRequested: 2 },
+      rolls: [
+        { sum: 2, average: 2, perDie: [{ original: [2], final: 2 }], used: [2] },
+        { sum: 3, average: 3, perDie: [{ original: [3], final: 3 }], used: [3] }
+      ]
+    });
 
     render(<DiceRoller />);
 

--- a/frontend/components/tools/DiceRoller.tsx
+++ b/frontend/components/tools/DiceRoller.tsx
@@ -208,28 +208,17 @@ const onRoll = async () => {
   try {
     setLoading(true);
 
-    // Make separate API calls for each dice configuration
-    const rollPromises = diceConfigs.map(async (config) => {
-      const payload = {
-        die: {
-          type: config.dieType,
-          sides: config.dieType === 'custom' ? config.sides : undefined
-        },
-        count: config.count
-        // Add any other required payload fields here if needed by your API
-      };
+    // Make a single batched API call for all dice configurations
+    const payloads = diceConfigs.map((config) => ({
+      die: {
+        type: config.dieType,
+        sides: config.dieType === 'custom' ? config.sides : undefined
+      },
+      count: config.count
+    }));
 
-  // Use shared API client helper so tests can mock this call
-  return await rollDice(payload as DiceRequest);
-    });
-
-    const results = (await Promise.all(rollPromises)) as DiceResponse[];
-
-    // Combine all results into a single response
-    let combinedResult: DiceResponse = {
-      rolls: results.flatMap(r => r.rolls),
-      summary: { totalRollsRequested: results.length }
-    };
+    // Use shared API client helper so tests can mock this call
+    let combinedResult = await rollDice(payloads as unknown as DiceRequest[]) as DiceResponse;
 
     // Apply local modifiers: reroll rules per-die, group modifier applied to sum only
     combinedResult = {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -11,8 +11,6 @@ import { rollDiceLocal } from '@/lib/local/dice';
 import { calculateFatLossLocal } from '@/lib/local/fatLoss';
 import { analyzeN26DataLocal } from '@/lib/local/n26';
 import { getSubstancesLocal, calculateToleranceLocal } from '@/lib/local/bloodLevel';
-import type { DiceRequest as DiceRequestFull } from '@/lib/types/dice';
-
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 /** Default request timeout in milliseconds (15 seconds). */
@@ -185,7 +183,7 @@ export interface RollDicePayload {
   advantage?: 'none' | 'adv' | 'dis';
 }
 
-export async function rollDice(payload: RollDicePayload) {
+export async function rollDice(payload: RollDicePayload | RollDicePayload[]) {
   return withLocalFallback(
     () =>
       apiRequest(
@@ -197,7 +195,8 @@ export async function rollDice(payload: RollDicePayload) {
         },
         'Roll API error',
       ),
-    () => rollDiceLocal(payload as DiceRequestFull),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    () => rollDiceLocal(payload as any),
   );
 }
 

--- a/frontend/lib/local/dice.ts
+++ b/frontend/lib/local/dice.ts
@@ -51,7 +51,21 @@ function buildStats(perDie: PerDieDetail[], used: number[]): DiceRollResult {
   return { perDie, used, sum, average, median: median(sorted), spread };
 }
 
-export function rollDiceLocal(request: DiceRequest): DiceResponse {
+export function rollDiceLocal(request: DiceRequest | DiceRequest[]): DiceResponse {
+  if (Array.isArray(request)) {
+    const results = request.map((r) => rollDiceLocalSingle(r));
+    return {
+      rolls: results.flatMap((r) => r.rolls),
+      summary: {
+        totalRollsRequested: results.reduce((acc, curr) => acc + curr.summary.totalRollsRequested, 0)
+      }
+    };
+  }
+
+  return rollDiceLocalSingle(request);
+}
+
+function rollDiceLocalSingle(request: DiceRequest): DiceResponse {
   if (!request.count || request.count <= 0) {
     throw new Error('count must be > 0');
   }


### PR DESCRIPTION
💡 **What:** Modified the `backend/src/api/dice.rs` `roll` endpoint to accept either a single `DiceRequest` object or an array of `DiceRequest` objects (using `serde(untagged)`). Adapted the `frontend/lib/api/client.ts` to accept payload arrays, the `frontend/lib/local/dice.ts` to execute them, and updated the `frontend/components/tools/DiceRoller.tsx` client component to send a single array payload rather than using `Promise.all` across N parallel network requests.

🎯 **Why:** The previous architecture made an independent API POST request for every single dice configuration in the roller. In network scenarios, hitting `Promise.all` with N network requests incurs significant TCP and TLS overhead per call, heavily delays rendering for complex scenarios, and easily triggers the rate limits on the backend endpoints (e.g., throwing Too Many Requests errors quickly). Batching solves all of this by making a single HTTP request containing an array.

📊 **Measured Improvement:** Since Postgres is unavailable to spin up the local server, I could only execute the local logic timing via unit tests. Because batching introduces minor iteration overhead locally when bypassing the network completely, it doesn't show a local performance gain. However, removing N+1 HTTP connection requests is a guaranteed, significant network speed improvement for a live app.


---
*PR created automatically by Jules for task [1685899616066967868](https://jules.google.com/task/1685899616066967868) started by @Ch3fUlrich*