### PR TITLE
🧹 [Code Health] Remove leftover console.log in api_substances test

### DIFF
--- a/frontend/__tests__/api_substances.test.tsx
+++ b/frontend/__tests__/api_substances.test.tsx
@@ -9,6 +9,5 @@ describe('API Client - getToleranceSubstances', () => {
     expect(substances.length).toBeGreaterThan(0);
     expect(substances[0]).toHaveProperty('id');
     expect(substances[0]).toHaveProperty('name');
-    console.log('Substances:', substances);
   });
 });


### PR DESCRIPTION
🎯 **What:** Removed a leftover `console.log` statement from `frontend/__tests__/api_substances.test.tsx`.
💡 **Why:** `console.log` statements in tests are generally considered code clutter and can pollute the test output, making it harder to read and debug actual issues. Removing it improves code health and maintainability.
✅ **Verification:** Verified the removal visually and ran the frontend tests (`pnpm --filter frontend test --run`) to ensure no regressions were introduced. The tests for `api_substances` pass successfully.
✨ **Result:** A cleaner test file with no unnecessary console output during test execution.

---
*PR created automatically by Jules for task [17303075656821747927](https://jules.google.com/task/17303075656821747927) started by @Ch3fUlrich*