### PR TITLE
🔒 fix(timeline): resolve DOM XSS vulnerability in History Panel

### DIFF
--- a/frontend/public/timeline/src/editor/timeline-editor.js
+++ b/frontend/public/timeline/src/editor/timeline-editor.js
@@ -5254,7 +5254,7 @@
       button.type = "button";
       button.className = "timeline-history-button";
       button.dataset.historyIndex = String(index);
-      button.innerHTML = `<span class="timeline-history-label">${entry.label}</span><span class="timeline-history-meta">${entry.at}</span>`;
+      button.innerHTML = `<span class="timeline-history-label">${escapeHtml(entry.label)}</span><span class="timeline-history-meta">${escapeHtml(entry.at)}</span>`;
 
       item.appendChild(button);
       state.ui.historyList.appendChild(item);


### PR DESCRIPTION
🎯 **What:** Fixed a DOM-based Cross-Site Scripting (XSS) vulnerability in the History Panel of the timeline editor where `entry.label` and `entry.at` were injected directly into `innerHTML` without sanitization.

⚠️ **Risk:** If left unfixed, an attacker could potentially execute malicious JavaScript in the victim's browser if they manage to create timeline entries with malicious payloads in the label or metadata fields.

🛡️ **Solution:** Wrapped `entry.label` and `entry.at` with the existing `escapeHtml()` function before concatenating them into the HTML string, effectively neutralizing any malicious tags or scripts.

---
*PR created automatically by Jules for task [17458890523274804806](https://jules.google.com/task/17458890523274804806) started by @Ch3fUlrich*