### PR TITLE
🧹 refactor(frontend): improve type safety for rollDice local fallback

### DIFF
--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -8,6 +8,7 @@ import {
   checkBackend,
 } from '@/lib/api/backendStatus';
 import { rollDiceLocal, saveDiceRollLocal, getDiceHistoryLocal } from '@/lib/local/dice';
+import type { DiceRequest } from '@/lib/types/dice';
 import { calculateFatLossLocal } from '@/lib/local/fatLoss';
 import { analyzeN26DataLocal } from '@/lib/local/n26';
 import { getSubstancesLocal, calculateToleranceLocal } from '@/lib/local/bloodLevel';
@@ -185,13 +186,7 @@ function authDelete<T>(path: string, errorPrefix: string): Promise<T> {
 
 // ─── Dice ────────────────────────────────────────────────────────────────────
 
-export interface RollDicePayload {
-  die: { type: string; sides?: number };
-  count: number;
-  advantage?: 'none' | 'adv' | 'dis';
-}
-
-export async function rollDice(payload: RollDicePayload | RollDicePayload[]) {
+export async function rollDice(payload: DiceRequest | DiceRequest[]) {
   return withLocalFallback(
     () =>
       apiRequest(
@@ -203,8 +198,7 @@ export async function rollDice(payload: RollDicePayload | RollDicePayload[]) {
         },
         'Roll API error',
       ),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    () => rollDiceLocal(payload as any),
+    () => rollDiceLocal(payload),
   );
 }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the duplicated `RollDicePayload` interface and used the standard `DiceRequest` interface. Removed the `any` cast and `eslint-disable` comment on the `rollDiceLocal` fallback function.

💡 **Why:** How this improves maintainability
The `any` cast was hiding type definitions that should match. Standardizing on `DiceRequest` ensures any updates to the Dice properties will appropriately fail typechecks across the file, removing potential for runtime errors.

✅ **Verification:** How you confirmed the change is safe
Ran `pnpm --filter frontend test --run`, `pnpm --filter frontend run build`, `pnpm --filter frontend run lint`, as well as backend tests via `cd backend && cargo check && cargo test`. Tests passed.

✨ **Result:** The improvement achieved
A cleaner `rollDice` definition without any ts-lint bypasses.

---
*PR created automatically by Jules for task [17596887122319392713](https://jules.google.com/task/17596887122319392713) started by @Ch3fUlrich*