### PR TITLE
docs(contributing): update patch versioning description

### DIFF
--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -447,7 +447,7 @@ When adding a new tool to the project:
 The project follows [Semantic Versioning](https://semver.org/):
 - MAJOR: Breaking changes
 - MINOR: New features (backward compatible)
-- PATCH: Bug fixes
+- PATCH: Bug fixes (backward compatible)
 
 Releases are fully automated via [semantic-release](https://github.com/semantic-release/semantic-release). When commits land on `main`, semantic-release analyzes the conventional commit messages, determines the next version, creates a GitHub Release with auto-generated release notes, and tags the commit. No manual CHANGELOG updates or version bumps are needed.
 


### PR DESCRIPTION
Updated the documentation in `docs/CONTRIBUTING.md` to correctly describe the scope of `PATCH` versions as backward compatible bug fixes.

---
*PR created automatically by Jules for task [10370093501908399232](https://jules.google.com/task/10370093501908399232) started by @Ch3fUlrich*