### PR TITLE
🧹 refactor(oidc): flatten deeply nested nonce validation block

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -358,17 +358,15 @@ pub async fn callback(
     if let Some(store_arc) = store {
         let mut guard = store_arc.lock().await;
         // attempt to take nonce by state
-        if let Some(_state) = q.state.clone() {
+        if q.state.is_some() {
             if let Some(stored_nonce) = stored_nonce {
                 // compare nonces if claims provided
-                if let Some(c) = &claims {
-                    if let Some(token_nonce) = c.nonce() {
-                        if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
-                        }
+                if let Some(token_nonce) = claims.as_ref().and_then(|c| c.nonce()) {
+                    if token_nonce.secret() != stored_nonce.as_str() {
+                        return axum::http::Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body("nonce mismatch".to_string())
+                            .unwrap_or_default();
                     }
                 }
             } else {

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a deeply nested `if let Some(...)` chain in the OIDC state/nonce validation block.
💡 **Why:** Flattening deeply nested code improves readability and maintainability by making the logical flow easier to follow and reducing cognitive load for future developers. It also removes an unnecessary allocation (`q.state.clone()`).
✅ **Verification:** I confirmed the change is safe by successfully running `cargo check`, `cargo fmt`, `cargo clippy`, and the entire `cargo test` suite on the backend. No regressions were introduced and all 152 backend tests pass.
✨ **Result:** The code block is now much cleaner, utilizing `claims.as_ref().and_then(|c| c.nonce())` to compress the nested `if` statements into a single, straightforward condition.

---
*PR created automatically by Jules for task [13058548503568621506](https://jules.google.com/task/13058548503568621506) started by @Ch3fUlrich*