### PR TITLE
🧹 [Code Health] Refactor deeply nested if blocks in OIDC callback

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -358,18 +358,19 @@ pub async fn callback(
     if let Some(store_arc) = store {
         let mut guard = store_arc.lock().await;
         // attempt to take nonce by state
-        if let Some(_state) = q.state.clone() {
+        if q.state.is_some() {
             if let Some(stored_nonce) = stored_nonce {
                 // compare nonces if claims provided
-                if let Some(c) = &claims {
-                    if let Some(token_nonce) = c.nonce() {
-                        if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
-                        }
-                    }
+                let is_mismatch = claims
+                    .as_ref()
+                    .and_then(|c| c.nonce())
+                    .is_some_and(|token_nonce| token_nonce.secret() != stored_nonce.as_str());
+
+                if is_mismatch {
+                    return axum::http::Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body("nonce mismatch".to_string())
+                        .unwrap_or_default();
                 }
             } else {
                 // no stored state; continue but warn

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** Refactored the deeply nested `if let` blocks around line 366 in `backend/src/api/oidc.rs`.
💡 **Why:** Flattening the nesting using `Option` combinators (`and_then`, `is_some_and`) significantly improves code readability and maintainability while preserving the exact same functionality. It also eliminates an unnecessary `.clone()` on `q.state`.
✅ **Verification:** Verified the code compiles by running `cargo check`, checked formatting with `cargo fmt`, ensured code quality with `cargo clippy`, and confirmed no functionality was broken by running the full backend test suite with `cargo test`. All passed. Requested code review to confirm correctness.
✨ **Result:** The `oidc.rs` file is now much easier to read and maintain, with the deep nesting successfully flattened.

---
*PR created automatically by Jules for task [5734196265170664795](https://jules.google.com/task/5734196265170664795) started by @Ch3fUlrich*