### PR TITLE
🧹 refactor(backend): improve code health and error handling in OIDC handlers

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -34,6 +34,10 @@ pub struct OidcStartQuery {
     pub _redirect_to: Option<String>,
 }
 
+fn error_response(status: StatusCode, msg: impl Into<String>) -> axum::http::Response<String> {
+    axum::http::Response::builder().status(status).body(msg.into()).unwrap_or_default()
+}
+
 pub async fn start(
     Query(_q): Query<OidcStartQuery>,
     Extension(store): Extension<Option<Arc<Mutex<SessionStore>>>>,
@@ -41,48 +45,45 @@ pub async fn start(
     let issuer = match std::env::var("OIDC_ISSUER") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_ISSUER not configured".to_string())
-                .unwrap_or_default()
+            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "OIDC_ISSUER not configured")
         }
     };
     let client_id = match std::env::var("OIDC_CLIENT_ID") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_CLIENT_ID not configured".to_string())
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OIDC_CLIENT_ID not configured",
+            )
         }
     };
     let redirect = match std::env::var("OIDC_REDIRECT_URI") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_REDIRECT_URI not configured".to_string())
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OIDC_REDIRECT_URI not configured",
+            )
         }
     };
 
     let issuer_url = match IssuerUrl::new(issuer.clone()) {
         Ok(u) => u,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("invalid OIDC_ISSUER: {e}"))
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid OIDC_ISSUER: {e}"),
+            )
         }
     };
 
     let http_client = match build_oidc_http_client() {
         Ok(client) => client,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("OIDC HTTP client failed: {e}"))
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("OIDC HTTP client failed: {e}"),
+            )
         }
     };
 
@@ -90,26 +91,29 @@ pub async fn start(
         match CoreProviderMetadata::discover_async(issuer_url, &http_client).await {
             Ok(m) => m,
             Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("OIDC discovery failed: {e}"))
-                    .unwrap_or_default()
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("OIDC discovery failed: {e}"),
+                )
             }
         };
+
+    let redirect_uri = match RedirectUrl::new(redirect.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid OIDC_REDIRECT_URI: {e}"),
+            )
+        }
+    };
+
     let client = CoreClient::from_provider_metadata(
         provider_metadata,
         ClientId::new(client_id.clone()),
         None,
     )
-    .set_redirect_uri(match RedirectUrl::new(redirect.clone()) {
-        Ok(r) => r,
-        Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("invalid OIDC_REDIRECT_URI: {e}"))
-                .unwrap_or_default()
-        }
-    });
+    .set_redirect_uri(redirect_uri);
 
     // generate state and nonce
     let mut state_bytes = [0u8; 16];
@@ -146,46 +150,40 @@ pub async fn callback(
     _headers: HeaderMap,
 ) -> axum::http::Response<String> {
     if q.code.is_empty() {
-        return axum::http::Response::builder()
-            .status(StatusCode::BAD_REQUEST)
-            .body("missing code".to_string())
-            .unwrap_or_default();
+        return error_response(StatusCode::BAD_REQUEST, "missing code");
     }
 
     let issuer = match std::env::var("OIDC_ISSUER") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_ISSUER not configured".to_string())
-                .unwrap_or_default()
+            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "OIDC_ISSUER not configured")
         }
     };
     let client_id = match std::env::var("OIDC_CLIENT_ID") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_CLIENT_ID not configured".to_string())
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OIDC_CLIENT_ID not configured",
+            )
         }
     };
     let client_secret = match std::env::var("OIDC_CLIENT_SECRET") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_CLIENT_SECRET not configured".to_string())
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OIDC_CLIENT_SECRET not configured",
+            )
         }
     };
     let redirect = match std::env::var("OIDC_REDIRECT_URI") {
         Ok(v) => v,
         Err(_) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body("OIDC_REDIRECT_URI not configured".to_string())
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OIDC_REDIRECT_URI not configured",
+            )
         }
     };
 
@@ -193,20 +191,20 @@ pub async fn callback(
     let issuer_url = match IssuerUrl::new(issuer.clone()) {
         Ok(u) => u,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("invalid OIDC_ISSUER: {e}"))
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid OIDC_ISSUER: {e}"),
+            )
         }
     };
 
     let http_client = match build_oidc_http_client() {
         Ok(client) => client,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("OIDC HTTP client failed: {e}"))
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("OIDC HTTP client failed: {e}"),
+            )
         }
     };
 
@@ -214,46 +212,45 @@ pub async fn callback(
         match CoreProviderMetadata::discover_async(issuer_url, &http_client).await {
             Ok(m) => m,
             Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("OIDC discovery failed: {e}"))
-                    .unwrap_or_default()
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("OIDC discovery failed: {e}"),
+                )
             }
         };
+
+    let redirect_uri = match RedirectUrl::new(redirect.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid OIDC_REDIRECT_URI: {e}"),
+            )
+        }
+    };
 
     let client = CoreClient::from_provider_metadata(
         provider_metadata,
         ClientId::new(client_id.clone()),
         Some(ClientSecret::new(client_secret.clone())),
     )
-    .set_redirect_uri(match RedirectUrl::new(redirect.clone()) {
-        Ok(r) => r,
-        Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("invalid OIDC_REDIRECT_URI: {e}"))
-                .unwrap_or_default()
-        }
-    });
+    .set_redirect_uri(redirect_uri);
 
     // Exchange code for token
     let token_request = match client.exchange_code(AuthorizationCode::new(q.code.clone())) {
         Ok(req) => req,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("OIDC token request setup failed: {e}"))
-                .unwrap_or_default()
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("OIDC token request setup failed: {e}"),
+            )
         }
     };
 
     let token_response = match token_request.request_async(&http_client).await {
         Ok(t) => t,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body(format!("token exchange failed: {e}"))
-                .unwrap_or_default()
+            return error_response(StatusCode::BAD_REQUEST, format!("token exchange failed: {e}"))
         }
     };
 
@@ -287,10 +284,7 @@ pub async fn callback(
     let email = claims.as_ref().and_then(|c| c.email().map(|e| e.to_string()));
 
     if subject.is_empty() {
-        return axum::http::Response::builder()
-            .status(StatusCode::BAD_REQUEST)
-            .body("missing subject in id token".to_string())
-            .unwrap_or_default();
+        return error_response(StatusCode::BAD_REQUEST, "missing subject in id token");
     }
 
     // Find oauth_account by provider + subject
@@ -307,10 +301,7 @@ pub async fn callback(
         Ok(Some(rec)) => rec.try_get::<sqlx::types::Uuid, _>("user_id").ok(),
         Ok(None) => None,
         Err(e) => {
-            return axum::http::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(format!("DB error: {e}"))
-                .unwrap_or_default()
+            return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("DB error: {e}"))
         }
     };
 
@@ -327,20 +318,15 @@ pub async fn callback(
             .await
         {
             Ok(r) => r,
-            Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("DB error creating user: {e}"))
-                    .unwrap_or_default()
-            }
+            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, format!("DB error creating user: {e}")),
         };
         let id: sqlx::types::Uuid = match rec.try_get("id") {
             Ok(u) => u,
             Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("DB returned malformed id: {e}"))
-                    .unwrap_or_default()
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("DB returned malformed id: {e}"),
+                )
             }
         };
         // insert oauth_account
@@ -364,10 +350,7 @@ pub async fn callback(
                 if let Some(c) = &claims {
                     if let Some(token_nonce) = c.nonce() {
                         if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
+                            return error_response(StatusCode::BAD_REQUEST, "nonce mismatch");
                         }
                     }
                 }
@@ -403,10 +386,10 @@ pub async fn callback(
                 return http_resp;
             }
             Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("session create failed: {e}"))
-                    .unwrap_or_default()
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("session create failed: {e}"),
+                )
             }
         }
     }

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Deep nesting and repetitive boilerplate response generation in `backend/src/api/oidc.rs` were resolved by extracting variables and utilizing an `error_response` helper.

💡 **Why:** How this improves maintainability
The deeply nested code (such as nesting a `match` expression inside a builder argument) makes the code difficult to read. By extracting it to an intermediate variable, it is much easier to read and maintain. Furthermore, utilizing a common helper function simplifies error handling across the OIDC configuration and logic, drastically reducing boilerplate `axum::http::Response::builder().status(...).body(...).unwrap_or_default()` calls.

✅ **Verification:** How you confirmed the change is safe
Ran the backend linter via `cargo clippy`, formatted the codebase with `cargo fmt`, and successfully ran the test suite using `cargo test` to verify no regressions were introduced.

✨ **Result:** The improvement achieved
A much cleaner and flatter implementation of the OIDC `start` and `callback` handlers, maintaining all existing behaviors but with significantly less boilerplate and nested logic.

---
*PR created automatically by Jules for task [6040108585922880239](https://jules.google.com/task/6040108585922880239) started by @Ch3fUlrich*