### PR TITLE
🧹 Refactor deeply nested code in OIDC callback

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -34,6 +34,40 @@ pub struct OidcStartQuery {
     pub _redirect_to: Option<String>,
 }
 
+async fn create_oauth_user(
+    pool: &PgPool,
+    email: Option<String>,
+    subject: &str,
+    provider: &str,
+) -> Result<sqlx::types::Uuid, String> {
+    let em = email.clone().unwrap_or_else(|| format!("{}@oauth", subject));
+    let rec = sqlx::query(
+        "INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&em)
+    .bind("")
+    .bind(None::<String>)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| format!("DB error creating user: {e}"))?;
+
+    let id: sqlx::types::Uuid =
+        rec.try_get("id").map_err(|e| format!("DB returned malformed id: {e}"))?;
+
+    sqlx::query(
+        "INSERT INTO oauth_accounts (user_id, provider, provider_subject, metadata) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(id)
+    .bind(provider)
+    .bind(subject)
+    .bind(serde_json::json!({"email": email}))
+    .execute(pool)
+    .await
+    .map_err(|e| format!("DB error linking account: {e}"))?;
+
+    Ok(id)
+}
+
 pub async fn start(
     Query(_q): Query<OidcStartQuery>,
     Extension(store): Extension<Option<Arc<Mutex<SessionStore>>>>,
@@ -317,58 +351,30 @@ pub async fn callback(
     let uid = if let Some(uid) = user_id {
         uid
     } else {
-        // create new user
-        let em = email.clone().unwrap_or_else(|| format!("{}@oauth", &subject));
-        let rec = match sqlx::query("INSERT INTO users (email, password_hash, display_name) VALUES ($1, $2, $3) RETURNING id")
-            .bind(&em)
-            .bind("")
-            .bind(None::<String>)
-            .fetch_one(&*pool)
-            .await
-        {
-            Ok(r) => r,
+        match create_oauth_user(&pool, email.clone(), &subject, &provider).await {
+            Ok(id) => id,
             Err(e) => {
                 return axum::http::Response::builder()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("DB error creating user: {e}"))
-                    .unwrap_or_default()
+                    .body(e)
+                    .unwrap_or_default();
             }
-        };
-        let id: sqlx::types::Uuid = match rec.try_get("id") {
-            Ok(u) => u,
-            Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("DB returned malformed id: {e}"))
-                    .unwrap_or_default()
-            }
-        };
-        // insert oauth_account
-        let _ = sqlx::query("INSERT INTO oauth_accounts (user_id, provider, provider_subject, metadata) VALUES ($1, $2, $3, $4)")
-            .bind(id)
-            .bind(&provider)
-            .bind(&subject)
-            .bind(serde_json::json!({"email": email}))
-            .execute(&*pool)
-            .await;
-        id
+        }
     };
 
     // Validate state/nonce if we stored them during start
     if let Some(store_arc) = store {
         let mut guard = store_arc.lock().await;
         // attempt to take nonce by state
-        if let Some(_state) = q.state.clone() {
+        if q.state.is_some() {
             if let Some(stored_nonce) = stored_nonce {
                 // compare nonces if claims provided
-                if let Some(c) = &claims {
-                    if let Some(token_nonce) = c.nonce() {
-                        if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
-                        }
+                if let Some(token_nonce) = claims.as_ref().and_then(|c| c.nonce()) {
+                    if token_nonce.secret() != stored_nonce.as_str() {
+                        return axum::http::Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body("nonce mismatch".to_string())
+                            .unwrap_or_default();
                     }
                 }
             } else {

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is "Deeply nested code" within the OIDC `callback` endpoint (`backend/src/api/oidc.rs:333`).
💡 **Why:** Deeply nested match blocks make code harder to read, test, and maintain. By extracting the OAuth user creation logic into its own `async` helper function and replacing deeply nested `if let Some` statements, we reduce cognitive load and enhance maintainability. Additionally, this refactoring surfaces previously swallowed errors when inserting into the `oauth_accounts` table.
✅ **Verification:** I ran `cargo check`, `cargo fmt`, `cargo clippy`, and the full backend test suite (`cargo test`), which all passed successfully, ensuring no regressions.
✨ **Result:** The `callback` function is now much flatter, shorter, and easier to follow.

---
*PR created automatically by Jules for task [16374767928361598906](https://jules.google.com/task/16374767928361598906) started by @Ch3fUlrich*