### PR TITLE
🧪 Add integration assertions for fat loss handler tests

### DIFF
--- a/backend/src/api/fat_loss.rs
+++ b/backend/src/api/fat_loss.rs
@@ -20,7 +20,15 @@ mod tests {
     async fn test_calculate_fat_loss_valid() {
         let request = FatLossRequest { kcal_deficit: 3500.0, weight_loss_kg: 0.5 };
 
-        let _response = calculate_fat_loss(Json(request)).await;
-        // Response should be OK
+        let response = calculate_fat_loss(Json(request)).await;
+        assert_eq!(response.into_response().status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fat_loss_invalid() {
+        let request = FatLossRequest { kcal_deficit: 0.0, weight_loss_kg: 0.5 };
+
+        let response = calculate_fat_loss(Json(request)).await;
+        assert_eq!(response.into_response().status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The testing gap in `test_calculate_fat_loss_valid` was addressed by converting the response to an Axum response and checking its status code. Added a new test `test_calculate_fat_loss_invalid` to cover the scenario with a bad request.
📊 **Coverage:** The happy path and invalid request scenarios are now both correctly covered with status assertions.
✨ **Result:** Test coverage improved for the fat loss handler, verifying correctness.

---
*PR created automatically by Jules for task [14345674706433520868](https://jules.google.com/task/14345674706433520868) started by @Ch3fUlrich*