### PR TITLE
🧹 Refactor OIDC callback to eliminate deep nesting

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -354,66 +354,60 @@ pub async fn callback(
         id
     };
 
-    // Validate state/nonce if we stored them during start
-    if let Some(store_arc) = store {
-        let mut guard = store_arc.lock().await;
-        // attempt to take nonce by state
-        if let Some(_state) = q.state.clone() {
-            if let Some(stored_nonce) = stored_nonce {
-                // compare nonces if claims provided
-                if let Some(c) = &claims {
-                    if let Some(token_nonce) = c.nonce() {
-                        if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
-                        }
-                    }
-                }
-            } else {
-                // no stored state; continue but warn
-                tracing::warn!(
-                    "OIDC callback without stored state/nonce - CSRF protection disabled"
-                );
-            }
-        }
+    // If no session store present, just return link result
+    let Some(store_arc) = store else {
+        return axum::http::Response::builder()
+            .status(StatusCode::OK)
+            .body(format!("linked user {uid}"))
+            .unwrap_or_default();
+    };
 
-        // Create session
-        match guard.create_session(uid, 60 * 60 * 24).await {
-            Ok(sid) => {
-                // Only add Secure flag when not running on localhost
-                let secure_flag = match std::env::var("ALLOWED_ORIGINS") {
-                    Ok(origins)
-                        if origins.contains("localhost") || origins.contains("127.0.0.1") =>
-                    {
-                        ""
-                    }
-                    _ => "; Secure",
-                };
-                let cookie = format!("sid={sid}; HttpOnly; Path=/; SameSite=Lax{secure_flag}");
-                // Redirect to frontend (if configured) with cookie set
-                let frontend = std::env::var("FRONTEND_URL").unwrap_or_else(|_| "/".to_string());
-                let http_resp = axum::http::Response::builder()
-                    .status(StatusCode::FOUND)
-                    .header(header::SET_COOKIE, cookie)
-                    .header(header::LOCATION, frontend)
-                    .body(String::new())
-                    .unwrap_or_default();
-                return http_resp;
+    // Validate state/nonce if we stored them during start
+    let mut guard = store_arc.lock().await;
+    // attempt to take nonce by state
+    if q.state.is_some() {
+        if let Some(stored_nonce) = stored_nonce {
+            // compare nonces if claims provided
+            let token_nonce = claims.as_ref().and_then(|c| c.nonce());
+            if let Some(token_nonce) = token_nonce {
+                if token_nonce.secret() != stored_nonce.as_str() {
+                    return axum::http::Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body("nonce mismatch".to_string())
+                        .unwrap_or_default();
+                }
             }
-            Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("session create failed: {e}"))
-                    .unwrap_or_default()
-            }
+        } else {
+            // no stored state; continue but warn
+            tracing::warn!("OIDC callback without stored state/nonce - CSRF protection disabled");
         }
     }
 
-    // If no session store present, just return link result
+    // Create session
+    let sid = match guard.create_session(uid, 60 * 60 * 24).await {
+        Ok(sid) => sid,
+        Err(e) => {
+            return axum::http::Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(format!("session create failed: {e}"))
+                .unwrap_or_default();
+        }
+    };
+
+    // Only add Secure flag when not running on localhost
+    let secure_flag = match std::env::var("ALLOWED_ORIGINS") {
+        Ok(origins) if origins.contains("localhost") || origins.contains("127.0.0.1") => "",
+        _ => "; Secure",
+    };
+
+    let cookie = format!("sid={sid}; HttpOnly; Path=/; SameSite=Lax{secure_flag}");
+    // Redirect to frontend (if configured) with cookie set
+    let frontend = std::env::var("FRONTEND_URL").unwrap_or_else(|_| "/".to_string());
+
     axum::http::Response::builder()
-        .status(StatusCode::OK)
-        .body(format!("linked user {uid}"))
+        .status(StatusCode::FOUND)
+        .header(header::SET_COOKIE, cookie)
+        .header(header::LOCATION, frontend)
+        .body(String::new())
         .unwrap_or_default()
 }

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** Extracted the `store` existence check into an early return, and flattened nested blocks for evaluating the state nonce and extracting `sid` during `create_session` within `backend/src/api/oidc.rs`.
💡 **Why:** The deeply nested codebase made it challenging to comprehend control flow and error states. Unnesting improves overall maintainability and readability by eliminating unnecessary indentation and isolating error handling.
✅ **Verification:** Ran `cargo clippy`, `cargo fmt`, and `cargo test` to verify the refactored code's syntactic validity and equivalence in behavior. Verified all integration and unit tests are passing successfully.
✨ **Result:** A flatter and cleaner `oidc_callback` function that relies on idiomatic Rust early returns.

---
*PR created automatically by Jules for task [2560651251843285543](https://jules.google.com/task/2560651251843285543) started by @Ch3fUlrich*