### PR TITLE
🧹 refactor(api): flatten deeply nested logic in dice history

### DIFF
--- a/backend/src/api/dice_history.rs
+++ b/backend/src/api/dice_history.rs
@@ -24,6 +24,18 @@ pub struct HistoryEntry {
     pub created_at: String,
 }
 
+fn extract_sid(headers: &HeaderMap) -> Option<String> {
+    let cookie_header =
+        headers.get(axum::http::header::COOKIE).and_then(|v| v.to_str().ok()).unwrap_or("");
+    cookie_header.split(';').map(str::trim).find_map(|part| {
+        let mut kv = part.splitn(2, '=');
+        match (kv.next(), kv.next()) {
+            (Some("sid"), Some(v)) => Some(v.to_string()),
+            _ => None,
+        }
+    })
+}
+
 // POST /api/tools/dice/save
 pub async fn save(
     // Try to extract authenticated user; if missing, we'll fall back to session-store
@@ -34,117 +46,79 @@ pub async fn save(
     Json(req): Json<SaveRequest>,
 ) -> impl IntoResponse {
     // If authenticated, persist to Postgres. Else try Redis-backed session store (sid cookie). Fallback to DB anonymous.
-    match auth {
-        Ok(AuthenticatedUser(user)) => {
-            let payload = req.payload;
-            let row = sqlx::query(
-                "INSERT INTO dice_rolls (user_id, payload) VALUES ($1, $2) RETURNING id::text",
+    if let Ok(AuthenticatedUser(user)) = auth {
+        let payload = req.payload;
+        let row = sqlx::query(
+            "INSERT INTO dice_rolls (user_id, payload) VALUES ($1, $2) RETURNING id::text",
+        )
+        .bind(user.id)
+        .bind(payload)
+        .fetch_one(&*pool)
+        .await;
+        return match row {
+            Ok(rec) => {
+                let id: String = rec.try_get("id").unwrap_or_else(|_| String::new());
+                (StatusCode::CREATED, axum::Json(serde_json::json!({"id": id}))).into_response()
+            }
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({"error": format!("DB error: {}", e)})),
             )
-            .bind(user.id)
-            .bind(payload)
-            .fetch_one(&*pool)
+                .into_response(),
+        };
+    }
+
+    // attempt to use redis session store
+    if let Some(store_arc) = store {
+        if let Some(sid) = extract_sid(&headers) {
+            let guard = store_arc.lock().await;
+            let key = format!("history:{sid}");
+            let payload_str =
+                serde_json::to_string(&req.payload).unwrap_or_else(|_| "null".to_string());
+            let res: Result<(), redis::RedisError> = async {
+                let mut conn = guard.get_conn().await?;
+                let _: () = conn.lpush(&key, payload_str).await?;
+                let _: () = conn.ltrim(&key, 0, 49).await?;
+                let _: () = conn.expire(&key, 3600).await?;
+                Ok(())
+            }
             .await;
-            match row {
-                Ok(rec) => {
-                    let id: String = rec.try_get("id").unwrap_or_else(|_| String::new());
-                    (StatusCode::CREATED, axum::Json(serde_json::json!({"id": id}))).into_response()
-                }
-                Err(e) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    axum::Json(serde_json::json!({"error": format!("DB error: {}", e)})),
+            return match res {
+                Ok(()) => (
+                    StatusCode::CREATED,
+                    axum::Json(serde_json::json!({"note": "stored in session history"})),
                 )
                     .into_response(),
-            }
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::Json(serde_json::json!({"error": format!("redis error: {}", e)})),
+                )
+                    .into_response(),
+            };
         }
-        Err(_) => {
-            // attempt to use redis session store
-            if let Some(store_arc) = store {
-                // parse sid from headers
-                let cookie_header = headers
-                    .get(axum::http::header::COOKIE)
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("");
-                let sid_opt = cookie_header.split(';').map(str::trim).find_map(|part| {
-                    let mut kv = part.splitn(2, '=');
-                    match (kv.next(), kv.next()) {
-                        (Some("sid"), Some(v)) => Some(v.to_string()),
-                        _ => None,
-                    }
-                });
-                if let Some(sid) = sid_opt {
-                    let guard = store_arc.lock().await;
-                    let key = format!("history:{sid}");
-                    let payload_str =
-                        serde_json::to_string(&req.payload).unwrap_or_else(|_| "null".to_string());
-                    let res: Result<(), redis::RedisError> = async {
-                        let mut conn = guard.get_conn().await?;
-                        let _: () = conn.lpush(&key, payload_str).await?;
-                        let _: () = conn.ltrim(&key, 0, 49).await?;
-                        let _: () = conn.expire(&key, 3600).await?;
-                        Ok(())
-                    }
-                    .await;
-                    match res {
-                        Ok(()) => (
-                            StatusCode::CREATED,
-                            axum::Json(serde_json::json!({"note": "stored in session history"})),
-                        )
-                            .into_response(),
-                        Err(e) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            axum::Json(serde_json::json!({"error": format!("redis error: {}", e)})),
-                        )
-                            .into_response(),
-                    }
-                } else {
-                    // fallback to DB anonymous
-                    let row = sqlx::query("INSERT INTO dice_rolls (user_id, payload) VALUES (NULL, $1) RETURNING id::text")
-                        .bind(req.payload)
-                        .fetch_one(&*pool)
-                        .await;
-                    match row {
-                        Ok(rec) => {
-                            let id: String = rec.try_get("id").unwrap_or_else(|_| String::new());
-                            (
-                                StatusCode::CREATED,
-                                axum::Json(
-                                    serde_json::json!({"id": id, "note": "stored as anonymous"}),
-                                ),
-                            )
-                                .into_response()
-                        }
-                        Err(e) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            axum::Json(serde_json::json!({"error": format!("DB error: {}", e)})),
-                        )
-                            .into_response(),
-                    }
-                }
-            } else {
-                // no redis, persist anonymous
-                let row = sqlx::query("INSERT INTO dice_rolls (user_id, payload) VALUES (NULL, $1) RETURNING id::text")
-                    .bind(req.payload)
-                    .fetch_one(&*pool)
-                    .await;
-                match row {
-                    Ok(rec) => {
-                        let id: String = rec.try_get("id").unwrap_or_else(|_| String::new());
-                        (
-                            StatusCode::CREATED,
-                            axum::Json(
-                                serde_json::json!({"id": id, "note": "stored as anonymous"}),
-                            ),
-                        )
-                            .into_response()
-                    }
-                    Err(e) => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        axum::Json(serde_json::json!({"error": format!("DB error: {}", e)})),
-                    )
-                        .into_response(),
-                }
-            }
+    }
+
+    // fallback to DB anonymous
+    let row = sqlx::query(
+        "INSERT INTO dice_rolls (user_id, payload) VALUES (NULL, $1) RETURNING id::text",
+    )
+    .bind(req.payload)
+    .fetch_one(&*pool)
+    .await;
+    match row {
+        Ok(rec) => {
+            let id: String = rec.try_get("id").unwrap_or_else(|_| String::new());
+            (
+                StatusCode::CREATED,
+                axum::Json(serde_json::json!({"id": id, "note": "stored as anonymous"})),
+            )
+                .into_response()
         }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({"error": format!("DB error: {}", e)})),
+        )
+            .into_response(),
     }
 }
 
@@ -161,7 +135,7 @@ pub async fn history(
             .bind(user.id)
             .fetch_all(&*pool)
             .await;
-        match rows {
+        return match rows {
             Ok(rs) => {
                 let mut out: Vec<HistoryEntry> = Vec::new();
                 for r in rs {
@@ -179,53 +153,42 @@ pub async fn history(
                 axum::Json(serde_json::json!({"error": format!("DB error: {}", e)})),
             )
                 .into_response(),
-        }
-    } else {
-        // Try Redis session-backed anonymous history
-        if let Some(store) = store {
-            // parse sid from headers
-            let cookie_header =
-                headers.get(axum::http::header::COOKIE).and_then(|v| v.to_str().ok()).unwrap_or("");
-            let sid_opt = cookie_header.split(';').map(str::trim).find_map(|part| {
-                let mut kv = part.splitn(2, '=');
-                match (kv.next(), kv.next()) {
-                    (Some("sid"), Some(v)) => Some(v.to_string()),
-                    _ => None,
-                }
-            });
-            if let Some(sid) = sid_opt {
-                let guard = store.lock().await;
-                let key = format!("history:{sid}");
-                let vals: Result<Vec<String>, redis::RedisError> = async {
-                    let mut conn = guard.get_conn().await?;
-                    conn.lrange(&key, 0, 49).await
-                }
-                .await;
-                match vals {
-                    Ok(list) => {
-                        let now = Utc::now().to_rfc3339();
-                        let out: Vec<HistoryEntry> = list
-                            .into_iter()
-                            .map(|s| {
-                                let v: JsonValue =
-                                    serde_json::from_str(&s).unwrap_or(serde_json::json!(null));
-                                HistoryEntry { id: None, payload: v, created_at: now.clone() }
-                            })
-                            .collect();
-                        return (StatusCode::OK, axum::Json(out)).into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            axum::Json(serde_json::json!({"error": format!("redis error: {}", e)})),
-                        )
-                            .into_response()
-                    }
-                }
-            }
-        }
-        // Fallback: unauthorized
-        (StatusCode::UNAUTHORIZED, axum::Json(serde_json::json!({"error":"unauthorized"})))
-            .into_response()
+        };
     }
+
+    // Try Redis session-backed anonymous history
+    if let Some(store) = store {
+        if let Some(sid) = extract_sid(&headers) {
+            let guard = store.lock().await;
+            let key = format!("history:{sid}");
+            let vals: Result<Vec<String>, redis::RedisError> = async {
+                let mut conn = guard.get_conn().await?;
+                conn.lrange(&key, 0, 49).await
+            }
+            .await;
+            return match vals {
+                Ok(list) => {
+                    let now = Utc::now().to_rfc3339();
+                    let out: Vec<HistoryEntry> = list
+                        .into_iter()
+                        .map(|s| {
+                            let v: JsonValue =
+                                serde_json::from_str(&s).unwrap_or(serde_json::json!(null));
+                            HistoryEntry { id: None, payload: v, created_at: now.clone() }
+                        })
+                        .collect();
+                    (StatusCode::OK, axum::Json(out)).into_response()
+                }
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::Json(serde_json::json!({"error": format!("redis error: {}", e)})),
+                )
+                    .into_response(),
+            };
+        }
+    }
+
+    // Fallback: unauthorized
+    (StatusCode::UNAUTHORIZED, axum::Json(serde_json::json!({"error":"unauthorized"})))
+        .into_response()
 }

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The deeply nested matching blocks and duplicated DB logic in the `save` and `history` functions in `backend/src/api/dice_history.rs` were refactored.
💡 **Why:** This drastically improves readability and maintainability by using an early-return pattern and extracting repetitive code (parsing headers) into an `extract_sid` helper function.
✅ **Verification:** Verified via `cargo fmt`, `cargo clippy`, and `cargo test`, ensuring the refactoring did not alter any behavior.
✨ **Result:** A more readable, flattened control flow with no logic regressions.

---
*PR created automatically by Jules for task [7268180827192839861](https://jules.google.com/task/7268180827192839861) started by @Ch3fUlrich*