### PR TITLE
🧪 test(training): add edge case tests for estimate_1rm function

### DIFF
--- a/backend/src/tools/training/mod.rs
+++ b/backend/src/tools/training/mod.rs
@@ -364,6 +364,23 @@ mod tests {
     }
 
     #[test]
+    fn test_1rm_negative_weight() {
+        assert!(estimate_1rm(-10.0, 5).is_none());
+    }
+
+    #[test]
+    fn test_1rm_high_reps() {
+        let rm = estimate_1rm(100.0, 30).unwrap();
+        assert!((rm - 200.0).abs() < 0.1, "1RM estimate for high reps: {rm}");
+    }
+
+    #[test]
+    fn test_1rm_small_weight() {
+        let rm = estimate_1rm(0.5, 15).unwrap();
+        assert!((rm - 0.75).abs() < 0.01, "1RM estimate for small weight: {rm}");
+    }
+
+    #[test]
     fn test_volume_calculation() {
         let sets = vec![(100.0, 10u32), (90.0, 8), (80.0, 12)];
         let volume = compute_volume(&sets);

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** Added missing edge case tests for the `estimate_1rm` function in `backend/src/tools/training/compute.rs`.
💡 **Why:** The mathematical estimations for 1RM required tests covering edge case inputs (negative weights, very small weights, unusually high rep counts) to prevent incorrect calculations.
✅ **Verification:** Verified by running `cargo test test_1rm` and `cargo test` in the `backend/` directory without regressions.
✨ **Result:** Improved test reliability by covering floating-point math edge cases and boundary inputs.

---
*PR created automatically by Jules for task [17792536914331116780](https://jules.google.com/task/17792536914331116780) started by @Ch3fUlrich*