### PR TITLE
🧹 refactor(dice): flatten deeply nested batch roll logic

### DIFF
--- a/backend/src/api/dice.rs
+++ b/backend/src/api/dice.rs
@@ -113,20 +113,18 @@ pub async fn roll(
             let mut total_requested = 0;
 
             for req in reqs {
-                match dice_logic::handle_roll(req).await {
-                    Ok(mut resp) => {
-                        all_rolls.append(&mut resp.rolls);
-                        if let Some(summary) = resp.summary.as_object() {
-                            if let Some(count) =
-                                summary.get("totalRollsRequested").and_then(|v| v.as_u64())
-                            {
-                                total_requested += count;
-                            }
-                        }
-                    }
+                let mut resp = match dice_logic::handle_roll(req).await {
+                    Ok(r) => r,
                     Err(e) => {
                         return (axum::http::StatusCode::BAD_REQUEST, axum::Json(e)).into_response()
                     }
+                };
+
+                all_rolls.append(&mut resp.rolls);
+                if let Some(count) =
+                    resp.summary.get("totalRollsRequested").and_then(|v| v.as_u64())
+                {
+                    total_requested += count;
                 }
             }
 

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The deeply nested code inside the `RollPayload::Batch(reqs)` iteration in `backend/src/api/dice.rs` has been refactored. The `match` expression was un-nested by binding its success result directly to a mutable variable, allowing early returns on errors to keep the block flat.
💡 **Why:** By reducing nesting, the logic is much easier to read and maintain, improving overall code health. Removing the unneeded `as_object()` check further simplifies the code and adheres to cleaner `serde_json` idioms.
✅ **Verification:** I ran `cargo clippy` and `cargo test -- dice` to confirm that the refactored code has no linting warnings and functionality is completely preserved.
✨ **Result:** The batch roll logic is now flat and clean, with equivalent functional guarantees as before.

---
*PR created automatically by Jules for task [5710376545067728296](https://jules.google.com/task/5710376545067728296) started by @Ch3fUlrich*