### PR TITLE
🧹 refactor(oidc): flatten deeply nested code for nonce validation

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -358,17 +358,15 @@ pub async fn callback(
     if let Some(store_arc) = store {
         let mut guard = store_arc.lock().await;
         // attempt to take nonce by state
-        if let Some(_state) = q.state.clone() {
+        if q.state.is_some() {
             if let Some(stored_nonce) = stored_nonce {
                 // compare nonces if claims provided
-                if let Some(c) = &claims {
-                    if let Some(token_nonce) = c.nonce() {
-                        if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
-                        }
+                if let Some(token_nonce) = claims.as_ref().and_then(|c| c.nonce()) {
+                    if token_nonce.secret() != stored_nonce.as_str() {
+                        return axum::http::Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body("nonce mismatch".to_string())
+                            .unwrap_or_default();
                     }
                 }
             } else {

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** Flattened deeply nested `if` statements around nonce matching in `backend/src/api/oidc.rs`.
💡 **Why:** To improve code readability and maintainability by reducing nesting levels.
✅ **Verification:** Ran `cd backend && cargo fmt`, `cargo test`, and `cargo clippy -- -D warnings`. All checks passed.
✨ **Result:** Improved code readability in `backend/src/api/oidc.rs`.

---
*PR created automatically by Jules for task [5400792803084838732](https://jules.google.com/task/5400792803084838732) started by @Ch3fUlrich*