### PR TITLE
🧹 refactor(backend): reduce deep nesting in oidc callback handling

### DIFF
--- a/backend/src/api/oidc.rs
+++ b/backend/src/api/oidc.rs
@@ -355,65 +355,63 @@ pub async fn callback(
     };
 
     // Validate state/nonce if we stored them during start
-    if let Some(store_arc) = store {
-        let mut guard = store_arc.lock().await;
-        // attempt to take nonce by state
-        if let Some(_state) = q.state.clone() {
-            if let Some(stored_nonce) = stored_nonce {
+    let Some(store_arc) = store else {
+        // If no session store present, just return link result
+        return axum::http::Response::builder()
+            .status(StatusCode::OK)
+            .body(format!("linked user {uid}"))
+            .unwrap_or_default();
+    };
+
+    let mut guard = store_arc.lock().await;
+    // attempt to take nonce by state
+    if q.state.is_some() {
+        match stored_nonce {
+            Some(stored_nonce) => {
                 // compare nonces if claims provided
-                if let Some(c) = &claims {
-                    if let Some(token_nonce) = c.nonce() {
-                        if token_nonce.secret() != stored_nonce.as_str() {
-                            return axum::http::Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("nonce mismatch".to_string())
-                                .unwrap_or_default();
-                        }
-                    }
+                let nonce_mismatch = claims
+                    .as_ref()
+                    .and_then(|c| c.nonce())
+                    .map(|token_nonce| token_nonce.secret() != stored_nonce.as_str())
+                    .unwrap_or(false);
+
+                if nonce_mismatch {
+                    return axum::http::Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body("nonce mismatch".to_string())
+                        .unwrap_or_default();
                 }
-            } else {
+            }
+            None => {
                 // no stored state; continue but warn
                 tracing::warn!(
                     "OIDC callback without stored state/nonce - CSRF protection disabled"
                 );
             }
         }
-
-        // Create session
-        match guard.create_session(uid, 60 * 60 * 24).await {
-            Ok(sid) => {
-                // Only add Secure flag when not running on localhost
-                let secure_flag = match std::env::var("ALLOWED_ORIGINS") {
-                    Ok(origins)
-                        if origins.contains("localhost") || origins.contains("127.0.0.1") =>
-                    {
-                        ""
-                    }
-                    _ => "; Secure",
-                };
-                let cookie = format!("sid={sid}; HttpOnly; Path=/; SameSite=Lax{secure_flag}");
-                // Redirect to frontend (if configured) with cookie set
-                let frontend = std::env::var("FRONTEND_URL").unwrap_or_else(|_| "/".to_string());
-                let http_resp = axum::http::Response::builder()
-                    .status(StatusCode::FOUND)
-                    .header(header::SET_COOKIE, cookie)
-                    .header(header::LOCATION, frontend)
-                    .body(String::new())
-                    .unwrap_or_default();
-                return http_resp;
-            }
-            Err(e) => {
-                return axum::http::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(format!("session create failed: {e}"))
-                    .unwrap_or_default()
-            }
-        }
     }
 
-    // If no session store present, just return link result
-    axum::http::Response::builder()
-        .status(StatusCode::OK)
-        .body(format!("linked user {uid}"))
-        .unwrap_or_default()
+    // Create session
+    match guard.create_session(uid, 60 * 60 * 24).await {
+        Ok(sid) => {
+            // Only add Secure flag when not running on localhost
+            let secure_flag = match std::env::var("ALLOWED_ORIGINS") {
+                Ok(origins) if origins.contains("localhost") || origins.contains("127.0.0.1") => "",
+                _ => "; Secure",
+            };
+            let cookie = format!("sid={sid}; HttpOnly; Path=/; SameSite=Lax{secure_flag}");
+            // Redirect to frontend (if configured) with cookie set
+            let frontend = std::env::var("FRONTEND_URL").unwrap_or_else(|_| "/".to_string());
+            axum::http::Response::builder()
+                .status(StatusCode::FOUND)
+                .header(header::SET_COOKIE, cookie)
+                .header(header::LOCATION, frontend)
+                .body(String::new())
+                .unwrap_or_default()
+        }
+        Err(e) => axum::http::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(format!("session create failed: {e}"))
+            .unwrap_or_default(),
+    }
 }

--- a/backend/tests/training_integration.rs
+++ b/backend/tests/training_integration.rs
@@ -114,8 +114,14 @@ async fn test_training_measurements_crud() {
 
     let first_item = &data[0];
     assert_eq!(first_item.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
-    assert_eq!(first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 180.0);
+    assert_eq!(
+        first_item.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
+    assert_eq!(
+        first_item.get("heightCm").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        180.0
+    );
 
     // 4. Get latest measurement
     let resp_latest = server
@@ -128,7 +134,10 @@ async fn test_training_measurements_crud() {
     let latest_json: serde_json::Value = resp_latest.json();
     let latest_data = latest_json.as_object().expect("Missing object");
     assert_eq!(latest_data.get("id").unwrap().as_str().unwrap(), id);
-    assert_eq!(latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(), 80.5);
+    assert_eq!(
+        latest_data.get("bodyWeightKg").unwrap().as_str().unwrap().parse::<f64>().unwrap(),
+        80.5
+    );
 
     // 5. Delete measurement
     let delete_url = format!("/api/tools/training/measurements/{}", id);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Deeply nested `if let` and `match` blocks in the OIDC callback handler (`backend/src/api/oidc.rs`) were simplified.

💡 **Why:** How this improves maintainability
The deeply nested structure made the code difficult to read and mentally parse. By employing idiomatic Rust constructs like `let-else` and unnesting checks via functional combinators (e.g., `.and_then`, `.map`), the code logic is now flatter and easier to follow. Early returns clarify edge cases immediately.

✅ **Verification:** How you confirmed the change is safe
1. **Compilation:** `cargo clippy -- -D warnings` passed cleanly.
2. **Formatting:** `cargo fmt` executed and confirmed no violations.
3. **Tests:** Full backend suite via `cargo test` ran and passed with no regressions.
4. **Behavior:** The refactoring strictly translates the existing logic. `match` statements were functionally replicated, and control flows (including the exact HTTP responses generated) remain identical.

✨ **Result:** The improvement achieved
A much cleaner, significantly less nested callback function that is easier to maintain and review, without altering any functionality.

---
*PR created automatically by Jules for task [6245516761722872626](https://jules.google.com/task/6245516761722872626) started by @Ch3fUlrich*