### PR TITLE
🧹 chore(frontend): remove leftover console.log in timeline generator

### DIFF
--- a/frontend/public/timeline/src/render/timeline-generator.js
+++ b/frontend/public/timeline/src/render/timeline-generator.js
@@ -301,8 +301,6 @@ function initializeTimeline() {
       },
     })
   );
-
-  console.log("Timeline initialized from config");
 }
 
 async function initializeTimelineWhenConfigReady() {


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` from `timeline-generator.js`.
💡 **Why:** To improve code cleanliness and prevent unnecessary console noise in the production environment.
✅ **Verification:** Verified by ensuring the line is removed using `git diff` and running the full backend and frontend test suites (`cargo test` and `pnpm test`).
✨ **Result:** A cleaner timeline generator module.

---
*PR created automatically by Jules for task [696600337829378380](https://jules.google.com/task/696600337829378380) started by @Ch3fUlrich*