### PR TITLE
🧪 Add integration test for migration failure

### DIFF
--- a/backend/tests/migrate_integration.rs
+++ b/backend/tests/migrate_integration.rs
@@ -83,3 +83,33 @@ async fn test_migrate_binary_missing_env() {
         stderr
     );
 }
+
+#[tokio::test]
+async fn test_migrate_binary_failure() {
+    let bad_database_url = "postgres://nonexistent:password@localhost:5432/nonexistent_db";
+
+    // Run the migrate binary
+    let output = Command::new("cargo")
+        .args(["run", "--bin", "migrate"])
+        .env("DATABASE_URL", bad_database_url)
+        .output()
+        .expect("Failed to run migrate binary");
+
+    // Should fail with exit code 1 (or at least non-zero)
+    assert!(!output.status.success(), "Migrate binary should fail with bad DB URL");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stderr.contains("Error") || stderr.contains("error"),
+        "Error message should be logged to stderr: {}",
+        stderr
+    );
+
+    assert!(
+        !stdout.contains("Migrations ran successfully"),
+        "Should not print success message on stdout: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing integration test for migration failure in the `migrate.rs` binary.
📊 **Coverage:** Scenarios covered now include the migrate binary failing to connect to the database (e.g. invalid credentials or network failure) and correctly returning a non-zero exit code.
✨ **Result:** Increased test coverage and confidence that migration errors will cause the deployment pipeline (which relies on the migrate binary exit status) to fail appropriately.

---
*PR created automatically by Jules for task [1070034158652642351](https://jules.google.com/task/1070034158652642351) started by @Ch3fUlrich*